### PR TITLE
Setup downloads resource files

### DIFF
--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -68,6 +68,8 @@ def download_uniprot_mappings():
     if not((reviewed_entries is not None) and
             (unreviewed_human_entries is not None)):
             return
+    unreviewed_human_entries = unreviewed_human_entries.decode('utf-8')
+    reviewed_entries = reviewed_entries.decode('utf-8')
     lines = reviewed_entries.strip('\n').split('\n')
     lines += unreviewed_human_entries.strip('\n').split('\n')[1:]
     # At this point, we need to clean up the gene names.

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 from builtins import dict, str
 import os
 import logging
-import requests
+import urllib.request
 
 
 logger = logging.getLogger(__name__)
@@ -30,13 +30,13 @@ def download_phosphositeplus():
     print("Note that PhosphoSitePlus data is not available for commercial use; "
           "please see full terms and conditions at: "
           "https://www.psp.org/staticDownloads")
-    resp = requests.get(psp_url)
+    resp = urllib.request.urlopen(psp_url)
     # Check the status code
-    if resp.status_code == 200:
+    if resp.status == 200:
         # Read and write as bytes (response.content)
         logger.info("Saving PhosphoSitePlus data to %s" % psp_filename)
         with open(psp_filename, 'wb') as f:
-            f.write(resp.content)
+            f.write(resp.read())
     else:
         logger.error("Error %s occurred downloading PhosphoSitePlus data" %
                      resp.status_code)
@@ -49,10 +49,10 @@ def download_uniprot_mappings():
         'format=tab&columns=id,genes(PREFERRED),' + \
         'entry%20name,database(RGD),database(MGI)'
     print('Downloading %s' % url)
-    res = requests.get(url)
-    if res.status_code != 200:
+    res = urllib.request.urlopen(url)
+    if res.status != 200:
         print('Failed to download "%s"' % url)
-    reviewed_entries = res.content
+    reviewed_entries = res.read()
 
     url = 'http://www.uniprot.org/uniprot/?' + \
         'sort=id&desc=no&compress=no&query=reviewed:no&fil=organism:' + \
@@ -60,16 +60,14 @@ def download_uniprot_mappings():
         'format=tab&columns=id,genes(PREFERRED),entry%20name,' + \
         'database(RGD),database(MGI)'
     print('Downloading %s' % url)
-    res = requests.get(url)
-    if res.status_code != 200:
+    res = urllib.request.urlopen(url)
+    if res.status != 200:
         print('Failed to download "%s"' % url)
-    unreviewed_human_entries = res.content
+    unreviewed_human_entries = res.read()
 
     if not((reviewed_entries is not None) and
             (unreviewed_human_entries is not None)):
             return
-    unreviewed_human_entries = unreviewed_human_entries.decode('utf-8')
-    reviewed_entries = reviewed_entries.decode('utf-8')
     lines = reviewed_entries.strip('\n').split('\n')
     lines += unreviewed_human_entries.strip('\n').split('\n')[1:]
     # At this point, we need to clean up the gene names.

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -21,6 +21,7 @@ if not os.path.isdir(resource_dir):
 
 
 psp_filename = os.path.join(resource_dir, 'Phosphorylation_site_dataset.tsv')
+up_filename = os.path.join(resource_dir, 'uniprot_entries.tsv')
 
 
 def download_phosphositeplus():
@@ -86,9 +87,8 @@ def download_uniprot_mappings():
     # Join all lines into a single string
     full_table = '\n'.join(lines)
     #fname = os.path.join(path, 'uniprot_entries.tsv')
-    fname = 'uniprot_entries.tsv'
-    logging.info('Saving into %s.' % fname)
-    with open(fname, 'wb') as fh:
+    logging.info('Saving into %s.' % up_filename)
+    with open(up_filename, 'wb') as fh:
         fh.write(full_table.encode('utf-8'))
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import sys
 from setuptools import setup
 from setuptools.command.install import install
-from distutils.command.build_py import build_py as _build_py
 
 
 class GetResources(install):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,22 @@
 import sys
 from setuptools import setup
+from setuptools.command.install import install
+from distutils.command.build_py import build_py as _build_py
+
+
+class GetResources(install):
+    """Post-installation for installation mode."""
+    def run(self):
+        super().run()
+        install.run(self)
+        from sitemapper.resources import download_phosphositeplus, \
+            download_uniprot_mappings
+        download_phosphositeplus()
+        download_uniprot_mappings()
+
 
 def main():
-    install_list = ['future', 'requests']
+    install_list = ['future', 'requests', 'indra']
     # Only install functools32 if we're in Python 2 (it's not available
     # for Python 3)
     if sys.version_info[0] == 2:
@@ -36,6 +50,9 @@ def main():
           install_requires=install_list,
           tests_require=['nose'],
           include_package_data=True,
+          cmdclass={
+              'install': GetResources,
+              },
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,11 @@ from distutils.command.build_py import build_py as _build_py
 class GetResources(install):
     """Post-installation for installation mode."""
     def run(self):
-        super().run()
-        install.run(self)
-        from sitemapper.resources import download_phosphositeplus, \
+        from protmapper.resources import download_phosphositeplus, \
             download_uniprot_mappings
         download_phosphositeplus()
         download_uniprot_mappings()
+        install.run(self)
 
 
 def main():


### PR DESCRIPTION
This PR changes setup.py such that it downloads resource files into the user's home folder before installing the package. 
- To work around the fact that dependencies are not available at the time of download, I also reimplemented resources.py to use urllib.request instead of requests.
- The UP resource file now also goes into the ~/.protmapper folder though at this point this file is redundant with the one in INDRA