### PR TITLE
Make resource downloads with nosetests work on Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+cache:
+    directories:
+        - $HOME/.cache/pip
 python:
   - "3.5"
   - "3.6"
@@ -6,8 +9,6 @@ before_install:
   - pip install nose coverage python-coveralls
 install:
   - pip install .
-#before_script:
-#  - python -m protmapper.resources
 script:
   - nosetests protmapper -s -v --with-coverage --cover-inclusive --cover-package=protmapper
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ before_install:
 install:
   - pip install .
 script:
-  - nosetests protmapper -s -v --with-coverage --cover-inclusive --cover-package=protmapper
+  - nosetests protmapper -v --with-coverage --cover-inclusive --cover-package=protmapper
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ before_install:
   - pip install nose coverage python-coveralls
 install:
   - pip install .
-before_script:
-  - python -m protmapper.resources
+#before_script:
+#  - python -m protmapper.resources
 script:
-  - nosetests protmapper -v --with-coverage --cover-inclusive --cover-package=protmapper
+  - nosetests protmapper -s -v --with-coverage --cover-inclusive --cover-package=protmapper
 after_success:
   - coveralls

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -25,7 +25,8 @@ def _download_from_s3(key, out_file):
     s3 = boto3.client('s3',
                       config=botocore.client.Config(
                           signature_version=botocore.UNSIGNED))
-    s3.download_file('bigmech', 'travis/%s' % key, out_file)
+    tc = boto3.s3.transfer.TransferConfig(use_threads=False)
+    s3.download_file('bigmech', 'travis/%s' % key, out_file, Config=tc)
 
 
 def download_phosphositeplus(out_file, cached=True):


### PR DESCRIPTION
This PR changes the Travis test to not do pre-downloading of resources (so we can actually test that runtime downloads are working as needed), and fixes a boto3/nosetests threading bug to make it work on Python 3.5.