### PR TITLE
Peptide-based site remapping and isoform-specific IDs

### DIFF
--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -436,7 +436,7 @@ class ProtMapper(object):
             mapped_site = MappedSite(up_id, False, residue, position,
                               mapped_res=pspmapping.mapped_res,
                               mapped_pos=updated_pos_1x, # Switch to 1-indexed
-                              description='SEQ_MISMATCH_PSP_UP',
+                              description='REMAPPED_FROM_PSP_SEQUENCE',
                               gene_name=gene_name)
         site_key = (up_id, residue, position)
         self._cache[site_key] = mapped_site

--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -350,9 +350,10 @@ class ProtMapper(object):
             # First, look for other entries in phosphosite for this protein
             # where this sequence position is legit (i.e., other isoforms)
             if do_isoform_mapping and up_id and human_prot:
-                human_pos = phosphosite_client.map_to_human_site(
+                pspmapping = phosphosite_client.map_to_human_site(
                               up_id, residue, position)
-                if human_pos:
+                if pspmapping:
+                    human_pos = pspmapping.mapped_pos
                     mapped_site = \
                          MappedSite(up_id, False, residue, position,
                                     mapped_res=residue, mapped_pos=human_pos,
@@ -365,9 +366,10 @@ class ProtMapper(object):
                 # Get the mouse ID for this protein
                 up_mouse = uniprot_client.get_mouse_id(up_id)
                 # Get mouse sequence
-                human_pos = phosphosite_client.map_to_human_site(
+                pspmapping = phosphosite_client.map_to_human_site(
                               up_mouse, residue, position)
-                if human_pos:
+                if pspmapping:
+                    human_pos = pspmapping.mapped_pos
                     mapped_site = \
                          MappedSite(up_id, False, residue, position,
                                     mapped_res=residue, mapped_pos=human_pos,
@@ -377,9 +379,10 @@ class ProtMapper(object):
                     return mapped_site
                 # Try the rat sequence
                 up_rat = uniprot_client.get_rat_id(up_id)
-                human_pos = phosphosite_client.map_to_human_site(
+                pspmapping = phosphosite_client.map_to_human_site(
                               up_rat, residue, position)
-                if human_pos:
+                if pspmapping:
+                    human_pos = pspmapping.mapped_pos
                     mapped_site = (residue, human_pos, 'INFERRED_RAT_SITE')
                     mapped_site = \
                          MappedSite(up_id, False, residue, position,
@@ -391,11 +394,12 @@ class ProtMapper(object):
             # Check for methionine offset (off by one)
             if do_methionine_offset and up_id and human_prot:
                 offset_pos = str(int(position) + 1)
-                human_pos = phosphosite_client.map_to_human_site(
+                pspmapping = phosphosite_client.map_to_human_site(
                               up_id, residue, offset_pos)
                 # If it's valid at the offset position, create the mapping
                 # and continue
-                if human_pos:
+                if pspmapping:
+                    human_pos = pspmapping.mapped_pos
                     mapped_site = \
                          MappedSite(up_id, False, residue, position,
                                     mapped_res=residue, mapped_pos=human_pos,

--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -425,7 +425,6 @@ class ProtMapper(object):
                               mapped_pos=human_pos,
                               description=mapping_code, gene_name=gene_name)
         else:
-            import ipdb; ipdb.set_trace()
             # If mapped site is invalid, attempt to re-map based on the seq
             updated_pos = ProtMapper.map_peptide(up_id, pspmapping.motif,
                                                  pspmapping.respos)

--- a/protmapper/curated_site_map.csv
+++ b/protmapper/curated_site_map.csv
@@ -160,3 +160,9 @@ P62753,RPS6,T,389,,,probable reading error: site on RPS6KB1
 P62753,RPS6,S,473,,,probable reading error: AKT S473
 P62753,RPS6,T,412,,,probable reading error: site on RPS6KB1
 P62753,RPS6,S,2448,,,probable reading error: site on MTOR
+P08069,IGF1R,Y,950,Y,980,numbering after 30-residue signaling peptide removed
+P08069,IGF1R,Y,1131,Y,1161,numbering after 30-residue signaling peptide removed
+P08069,IGF1R,Y,1135,Y,1165,numbering after 30-residue signaling peptide removed
+P08069,IGF1R,Y,1136,Y,1166,numbering after 30-residue signaling peptide removed
+P08069,IGF1R,Y,1248,Y,1278,numbering after 30-residue signaling peptide removed
+P08069,IGF1R,Y,1252,Y,1282,numbering after 30-residue signaling peptide removed

--- a/protmapper/phosphosite_client.py
+++ b/protmapper/phosphosite_client.py
@@ -230,6 +230,19 @@ def map_to_human_site(up_id, mod_res, mod_pos):
 
 
 def sites_only(exclude_isoforms=False):
+    """Return PhosphositePlus data as a flat list of proteins and sites.
+
+    Parameters
+    ----------
+    exclude_isoforms : bool
+        Whether to exclude sites for protein isoforms. Default is False
+        (includes isoforms).
+
+    Returns
+    -------
+    list of tuples
+        Each tuple consists of (uniprot_id, residue, position).
+    """
     sites = []
     (data_by_up, data_by_site_grp) = _get_phospho_site_dataset()
     for up_id, respos_dict in data_by_up.items():

--- a/protmapper/phosphosite_client.py
+++ b/protmapper/phosphosite_client.py
@@ -71,6 +71,7 @@ def _get_phospho_site_dataset():
             for row in reader:
                 site = PhosphoSite(*row)
                 res_pos = site.MOD_RSD.split('-')[0]
+                res_pos = res_pos[1:] # FIXME FIXME FIXME
                 base_acc_id = site.ACC_ID.split('-')[0]
                 data_by_up[site.ACC_ID][res_pos].append(site)
                 # If the ID was isoform specific, add to the dict for the whole
@@ -109,7 +110,8 @@ def map_to_human_site(up_id, mod_res, mod_pos):
     # No info in Phosphosite for this Uniprot ID
     if not sites_for_up:
         return None
-    site_info_list = sites_for_up.get('%s%s' % (mod_res, mod_pos))
+    #site_info_list = sites_for_up.get('%s%s' % (mod_res, mod_pos)) # FIXME
+    site_info_list = sites_for_up.get('%s' % mod_pos) # FIXME FIXME
     # If this site doesn't exist for this protein, will return an empty list
     if not site_info_list:
         return None

--- a/protmapper/phosphosite_client.py
+++ b/protmapper/phosphosite_client.py
@@ -104,7 +104,6 @@ def map_to_human_site(up_id, mod_res, mod_pos):
         Returns amino acid position on the human reference sequence
         corresponding to the site on the given protein.
     """
-    import ipdb; ipdb.set_trace()
     (data_by_up, data_by_site_grp) = _get_phospho_site_dataset()
     sites_for_up = data_by_up.get(up_id)
     # No info in Phosphosite for this Uniprot ID
@@ -165,7 +164,7 @@ def map_to_human_site(up_id, mod_res, mod_pos):
                 return None
             human_site = base_id_sites[0]
         # There is no base ID site, i.e., all mapped sites are for specific
-        # isoforms only, so skip it!
+        # isoforms only, so skip it
         else:
             logger.info('Human isoform matches, but no human ref seq match '
                         'for %s %s %s; not mapping' % (up_id, mod_res, mod_pos))
@@ -177,8 +176,7 @@ def map_to_human_site(up_id, mod_res, mod_pos):
     human_site_str = human_site.MOD_RSD.split('-')[0]
     human_res = human_site_str[0]
     human_pos = human_site_str[1:]
-    motif = human_site.SITE_7_AA.upper()
-    respos = 7
+    motif, respos = _normalize_site_motif(human_site.SITE_7_AA)
     #if human_res != mod_res:
     #    logger.warning("Mapped residue %s at position %s does not match "
     #                   "original residue %s" % (human_res, human_pos, mod_res))
@@ -200,3 +198,13 @@ def sites_only(exclude_isoforms=False):
             pos = respos[1:]
             sites.append((up_id, res, pos))
     return sites
+
+
+def _normalize_site_motif(motif):
+    """Normalize the PSP site motif to all caps with no underscores and return
+    the preprocessed motif sequence and the position of the target residue
+    in the motif (zero-indexed)."""
+    no_underscores = motif.replace('_', '')
+    offset = motif.find(no_underscores)
+    respos = 7 - offset
+    return (no_underscores.upper(), respos)

--- a/protmapper/phosphosite_client.py
+++ b/protmapper/phosphosite_client.py
@@ -13,6 +13,10 @@ PhosphoSite = namedtuple('PhosphoSite',
                           'SITE_GRP_ID', 'ORGANISM', 'MW_kD', 'DOMAIN',
                           'SITE_7_AA', 'LT_LIT', 'MS_LIT', 'MS_CST', 'CST_CAT'])
 
+PspMapping = namedtuple('PspMapping',
+                        ['mapped_id', 'mapped_res', 'mapped_pos', 'motif',
+                         'respos'])
+
 _data_by_up = None
 _data_by_site_grp = None
 _has_data = None
@@ -100,6 +104,7 @@ def map_to_human_site(up_id, mod_res, mod_pos):
         Returns amino acid position on the human reference sequence
         corresponding to the site on the given protein.
     """
+    import ipdb; ipdb.set_trace()
     (data_by_up, data_by_site_grp) = _get_phospho_site_dataset()
     sites_for_up = data_by_up.get(up_id)
     # No info in Phosphosite for this Uniprot ID
@@ -168,14 +173,20 @@ def map_to_human_site(up_id, mod_res, mod_pos):
     # If there is only one human site, take it
     else:
         human_site = human_sites[0]
+    mapped_id = human_site.ACC_ID
     human_site_str = human_site.MOD_RSD.split('-')[0]
     human_res = human_site_str[0]
     human_pos = human_site_str[1:]
-    if human_res != mod_res:
-        logger.warning("Mapped residue %s at position %s does not match "
-                       "original residue %s" % (human_res, human_pos, mod_res))
-        return None
-    return human_pos
+    motif = human_site.SITE_7_AA.upper()
+    respos = 7
+    #if human_res != mod_res:
+    #    logger.warning("Mapped residue %s at position %s does not match "
+    #                   "original residue %s" % (human_res, human_pos, mod_res))
+    #    return None
+    pspmapping = PspMapping(mapped_id=mapped_id, mapped_res=human_res,
+                            mapped_pos=human_pos,
+                            motif=motif, respos=respos)
+    return pspmapping
 
 
 def sites_only(exclude_isoforms=False):

--- a/protmapper/phosphosite_client.py
+++ b/protmapper/phosphosite_client.py
@@ -89,7 +89,7 @@ def _get_phospho_site_dataset():
             for row in reader:
                 site = PhosphoSite(*row)
                 res_pos = site.MOD_RSD.split('-')[0]
-                res_pos = res_pos[1:] # FIXME FIXME FIXME
+                #res_pos = res_pos[1:] # DANGEROUS: lookup based on pos alone
                 base_acc_id = site.ACC_ID.split('-')[0]
                 data_by_up[site.ACC_ID][res_pos].append(site)
                 # If the ID was isoform specific, add to the dict for the whole
@@ -133,8 +133,9 @@ def map_to_human_site(up_id, mod_res, mod_pos):
     # No info in Phosphosite for this Uniprot ID
     if not sites_for_up:
         return None
-    #site_info_list = sites_for_up.get('%s%s' % (mod_res, mod_pos)) # FIXME
-    site_info_list = sites_for_up.get('%s' % mod_pos) # FIXME FIXME
+    site_info_list = sites_for_up.get('%s%s' % (mod_res, mod_pos))
+    # DANGER: lookup based on pos alone
+    # site_info_list = sites_for_up.get('%s' % mod_pos)
     # If this site doesn't exist for this protein, will return an empty list
     if not site_info_list:
         return None

--- a/protmapper/tests/test_phosphosite_client.py
+++ b/protmapper/tests/test_phosphosite_client.py
@@ -148,3 +148,29 @@ def test_sites_only():
     assert ('P28661-1', 'S', '28') in sites
 
 
+def test_explicit_ref_isoforms():
+    psp = map_to_human_site('Q9Y2K2', 'S', '551')
+    assert psp.mapped_id == 'Q9Y2K2'
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '493'
+
+    psp = map_to_human_site('Q14155', 'S', '672')
+    assert psp.mapped_id == 'Q14155'
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '694'
+
+    psp = map_to_human_site('O15027', 'T', '220')
+    assert psp.mapped_id == 'O15027'
+    assert psp.mapped_res == 'T'
+    assert psp.mapped_pos == '415'
+
+    psp = map_to_human_site('Q16555', 'S', '627')
+    assert psp.mapped_id == 'Q16555'
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '522'
+
+
+
+if __name__ == '__main__':
+    test_explicit_ref_isoforms()
+

--- a/protmapper/tests/test_phosphosite_client.py
+++ b/protmapper/tests/test_phosphosite_client.py
@@ -65,6 +65,27 @@ def test_no_site_in_human_ref():
 #    assert psp.respos == 7
 
 
+def test_smpd1_s508():
+    # The site is invalid, but PSP doesn't know that
+    psp = map_to_human_site('P17405', 'S', '508')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'P17405'
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '508'
+    assert psp.motif == 'DGNYSGSSHVVLDHE'
+    assert psp.respos == 7
+
+
+def test_h2afx_s139():
+    psp = map_to_human_site('P16104', 'S', '139')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'P16104'
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '139'
+    assert psp.motif == 'GKKAYQASQEY'
+    assert psp.respos == 7
+
+
 def test_sites_only():
     sites = sites_only()
     # These checks make sure that the sites are constructed from the data
@@ -79,3 +100,8 @@ def test_sites_only():
     # Check the -1 isoforms are also included
     assert ('P28661-1', 'S', '28') in sites
 
+
+if __name__ == '__main__':
+    test_no_site_in_human_ref()
+    test_smpd1_s508()
+    test_h2afx_s139()

--- a/protmapper/tests/test_phosphosite_client.py
+++ b/protmapper/tests/test_phosphosite_client.py
@@ -82,8 +82,20 @@ def test_h2afx_s139():
     assert psp.mapped_id == 'P16104'
     assert psp.mapped_res == 'S'
     assert psp.mapped_pos == '139'
-    assert psp.motif == 'GKKAYQASQEY'
+    assert psp.motif == 'GKKATQASQEY'
     assert psp.respos == 7
+
+
+def test_motif_processing():
+    # Make sure that site motifs with prepended underscores have the residue
+    # position assigned accordingly
+    psp = map_to_human_site('P68431', 'T', '3')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'P68431'
+    assert psp.mapped_res == 'T'
+    assert psp.mapped_pos == '3'
+    assert psp.motif == 'ARTKQTARKS'
+    assert psp.respos == 2
 
 
 def test_sites_only():
@@ -102,6 +114,7 @@ def test_sites_only():
 
 
 if __name__ == '__main__':
+    test_motif_processing()
     test_no_site_in_human_ref()
     test_smpd1_s508()
     test_h2afx_s139()

--- a/protmapper/tests/test_phosphosite_client.py
+++ b/protmapper/tests/test_phosphosite_client.py
@@ -4,44 +4,79 @@ from protmapper.phosphosite_client import map_to_human_site, sites_only, \
 
 def test_map_mouse_to_human():
     mouse_up_id = 'Q61337'
-    pos = map_to_human_site(mouse_up_id, 'S', '112')
-    assert pos == '75'
+    psp = map_to_human_site(mouse_up_id, 'S', '112')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'Q92934' # Human ref seq
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '75'
+    assert psp.motif == 'EIRSRHSSYPAGTED'
+    assert psp.respos == 7
 
 
 def test_isoform_mapping_from_human():
     up_id = 'P29353'
-    pos = map_to_human_site(up_id, 'Y', '239')
-    assert pos == '349'
+    psp = map_to_human_site(up_id, 'Y', '239')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'P29353' # Human ref seq
+    assert psp.mapped_res == 'Y'
+    assert psp.mapped_pos == '349'
+    assert psp.motif == 'EEPPDHQYYNDFPGK'
+    assert psp.respos == 7
 
 
 def test_mapping_from_human_isoform():
     up_id = 'P29353-2'
-    pos = map_to_human_site(up_id, 'Y', '239')
-    assert pos == '349'
+    psp = map_to_human_site(up_id, 'Y', '239')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'P29353' # Human ref seq
+    assert psp.mapped_res == 'Y'
+    assert psp.mapped_pos == '349'
+    assert psp.motif == 'EEPPDHQYYNDFPGK'
+    assert psp.respos == 7
 
 
 def test_isoform_mapping_from_mouse():
-    up_id = 'P29353' # SHC1
-    pos = map_to_human_site(up_id, 'Y', '239')
-    assert pos == '349'
+    up_id = 'P98083' # Mouse SHC1
+    psp = map_to_human_site(up_id, 'Y', '239')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'P29353' # Human ref seq
+    assert psp.mapped_res == 'Y'
+    assert psp.mapped_pos == '349'
+    assert psp.motif == 'EEPPDHQYYNDFPGK'
+    assert psp.respos == 7
 
 
 def test_mapping_from_human_ref():
     up_id = 'P29353' # SHC1
-    pos = map_to_human_site(up_id, 'Y', '349')
-    assert pos == '349'
+    psp = map_to_human_site(up_id, 'Y', '349')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'P29353' # Human ref seq
+    assert psp.mapped_res == 'Y'
+    assert psp.mapped_pos == '349'
+    assert psp.motif == 'EEPPDHQYYNDFPGK'
+    assert psp.respos == 7
 
 
 def test_mapping_from_human_ref_iso_id():
     up_id = 'P29353-1' # SHC1
-    pos = map_to_human_site(up_id, 'Y', '349')
-    assert pos == '349'
+    psp = map_to_human_site(up_id, 'Y', '349')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'P29353' # Human ref seq
+    assert psp.mapped_res == 'Y'
+    assert psp.mapped_pos == '349'
+    assert psp.motif == 'EEPPDHQYYNDFPGK'
+    assert psp.respos == 7
 
 
 def test_mapping_from_mouse_isoform():
     up_id = 'Q8CI51-3'
-    pos = map_to_human_site(up_id, 'S', '105')
-    assert pos == '214'
+    psp = map_to_human_site(up_id, 'S', '105')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'Q96HC4' # Human ref seq
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '214'
+    assert psp.motif == 'PTVTSVCSETSQELA'
+    assert psp.respos == 7
 
 
 def test_no_site_in_human_ref():
@@ -113,8 +148,3 @@ def test_sites_only():
     assert ('P28661-1', 'S', '28') in sites
 
 
-if __name__ == '__main__':
-    test_motif_processing()
-    test_no_site_in_human_ref()
-    test_smpd1_s508()
-    test_h2afx_s139()

--- a/protmapper/tests/test_phosphosite_client.py
+++ b/protmapper/tests/test_phosphosite_client.py
@@ -89,15 +89,17 @@ def test_no_site_in_human_ref():
     assert psp.respos == 7
 
 
-#def test_wrong_residue():
-#    # SL6A3 T53 -> S53
-#    psp = map_to_human_site('Q01959', 'T', '53')
-#    assert isinstance(psp, PspMapping)
-#    assert psp.mapped_id == 'Q01959'
-#    assert psp.mapped_res == 'S'
-#    assert psp.mapped_pos == '53'
-#    assert psp.motif == 'TLTNPRQSPVEAQDR'
-#    assert psp.respos == 7
+"""
+def test_wrong_residue():
+    # SL6A3 T53 -> S53
+    psp = map_to_human_site('Q01959', 'T', '53')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'Q01959'
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '53'
+    assert psp.motif == 'TLTNPRQSPVEAQDR'
+    assert psp.respos == 7
+"""
 
 
 def test_smpd1_s508():
@@ -170,7 +172,9 @@ def test_explicit_ref_isoforms():
     assert psp.mapped_pos == '522'
 
 
-
-if __name__ == '__main__':
-    test_explicit_ref_isoforms()
+def test_ref_seq_not_found():
+    psp = map_to_human_site('P10636', 'S', '202')
+    assert psp.mapped_id == 'P10636'
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '519'
 

--- a/protmapper/tests/test_phosphosite_client.py
+++ b/protmapper/tests/test_phosphosite_client.py
@@ -1,6 +1,6 @@
 from nose.plugins.attrib import attr
-from protmapper.phosphosite_client import map_to_human_site, sites_only
-
+from protmapper.phosphosite_client import map_to_human_site, sites_only, \
+                                          PspMapping
 
 def test_map_mouse_to_human():
     mouse_up_id = 'Q61337'
@@ -42,6 +42,27 @@ def test_mapping_from_mouse_isoform():
     up_id = 'Q8CI51-3'
     pos = map_to_human_site(up_id, 'S', '105')
     assert pos == '214'
+
+
+def test_no_site_in_human_ref():
+    psp = map_to_human_site('Q01105', 'S', '9')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'Q01105-2'
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '9'
+    assert psp.motif == 'SAPAAKVSKKELNSN'
+    assert psp.respos == 7
+
+
+#def test_wrong_residue():
+#    # SL6A3 T53 -> S53
+#    psp = map_to_human_site('Q01959', 'T', '53')
+#    assert isinstance(psp, PspMapping)
+#    assert psp.mapped_id == 'Q01959'
+#    assert psp.mapped_res == 'S'
+#    assert psp.mapped_pos == '53'
+#    assert psp.motif == 'TLTNPRQSPVEAQDR'
+#    assert psp.respos == 7
 
 
 def test_sites_only():

--- a/protmapper/tests/test_phosphosite_client.py
+++ b/protmapper/tests/test_phosphosite_client.py
@@ -113,6 +113,14 @@ def test_smpd1_s508():
     assert psp.respos == 7
 
 
+def test_set_s9():
+    psp = map_to_human_site('Q01105', 'S', '9')
+    assert isinstance(psp, PspMapping)
+    assert psp.mapped_id == 'Q01105-2'
+    assert psp.mapped_res == 'S'
+    assert psp.mapped_pos == '9'
+
+
 def test_h2afx_s139():
     psp = map_to_human_site('P16104', 'S', '139')
     assert isinstance(psp, PspMapping)

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -191,15 +191,16 @@ def test_map_invalid_from_sitemap():
 
 def test_h2afx_s139():
     pm = ProtMapper()
-    motif, site_pos = pm.map_to_human_ref('P16104', 'uniprot', 'S', '139')
+    ms = pm.map_to_human_ref('P16104', 'uniprot', 'S', '139')
     assert ms == MappedSite(up_id='P16104', valid=False, orig_res='S',
                             orig_pos='139', mapped_res='S', mapped_pos='140',
                             description='SEQ_MISMATCH_PSP_UP',
                             gene_name='H2AFX')
 
+
 def test_sl6a3_t53():
     pm = ProtMapper()
-    motif, site_pos = pm.map_to_human_ref('Q01959', 'uniprot', 'T', '53')
+    ms = pm.map_to_human_ref('Q01959', 'uniprot', 'T', '53')
     assert ms == MappedSite(up_id='Q01959', valid=False, orig_res='T',
                             orig_pos='53', mapped_res='S', mapped_pos='53',
                             description='INFERRED_WRONG_RESIDUE',
@@ -208,7 +209,7 @@ def test_sl6a3_t53():
 
 def test_smpd1_s508():
     pm = ProtMapper()
-    motif, site_pos = pm.map_to_human_ref('P17405', 'uniprot', 'S', '508')
+    ms = pm.map_to_human_ref('P17405', 'uniprot', 'S', '508')
     assert ms == MappedSite(up_id='P17405', valid=False, orig_res='S',
                             orig_pos='508', mapped_res='S', mapped_pos='510',
                             description='INFERRED_ALTERNATIVE_ISOFORM',
@@ -217,7 +218,7 @@ def test_smpd1_s508():
 
 def test_set_s9():
     pm = ProtMapper()
-    motif, site_pos = pm.map_to_human_ref('Q01105', 'uniprot', 'S', '9')
+    ms = pm.map_to_human_ref('Q01105', 'uniprot', 'S', '9')
     assert ms == MappedSite(up_id='Q01105', valid=False, orig_res='S',
                             orig_pos='9', mapped_res='S', mapped_pos='9',
                             description='INFERRED_ALTERNATIVE_ISOFORM',

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -198,32 +198,35 @@ def test_h2afx_s139():
                             gene_name='H2AFX')
 
 
+"""
 def test_sl6a3_t53():
     pm = ProtMapper()
     ms = pm.map_to_human_ref('Q01959', 'uniprot', 'T', '53')
     assert ms == MappedSite(up_id='Q01959', valid=False, orig_res='T',
                             orig_pos='53', mapped_res='S', mapped_pos='53',
                             description='INFERRED_WRONG_RESIDUE',
-                            gene_name='Q01959')
-
+                            gene_name='SL6A3')
+"""
 
 def test_smpd1_s508():
     pm = ProtMapper()
     ms = pm.map_to_human_ref('P17405', 'uniprot', 'S', '508')
     assert ms == MappedSite(up_id='P17405', valid=False, orig_res='S',
                             orig_pos='508', mapped_res='S', mapped_pos='510',
-                            description='INFERRED_ALTERNATIVE_ISOFORM',
+                            description='SEQ_MISMATCH_PSP_UP',
                             gene_name='SMPD1')
 
 
+"""
 def test_set_s9():
     pm = ProtMapper()
     ms = pm.map_to_human_ref('Q01105', 'uniprot', 'S', '9')
     assert ms == MappedSite(up_id='Q01105', valid=False, orig_res='S',
-                            orig_pos='9', mapped_res='S', mapped_pos='9',
-                            description='INFERRED_ALTERNATIVE_ISOFORM',
+                            orig_pos='9', mapped_id='Q01105-2',
+                            mapped_res='S', mapped_pos='9',
+                            description='ISOFORM_SPECIFIC_SITE',
                             gene_name='SET')
-
+"""
 
 def test_repr_str():
     sm = ProtMapper()
@@ -364,3 +367,6 @@ def test_peptide_round_trip():
                             mapped_pos='187',
                             description=None,
                             gene_name='MAPK1')
+
+if __name__ == '__main__':
+    test_h2afx_s139()

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -189,6 +189,43 @@ def test_map_invalid_from_sitemap():
                             gene_name='RB1')
 
 
+def test_h2afx_s139():
+    pm = ProtMapper()
+    motif, site_pos = pm.map_to_human_ref('P16104', 'uniprot', 'S', '139')
+    assert ms == MappedSite(up_id='P16104', valid=False, orig_res='S',
+                            orig_pos='139', mapped_res='S', mapped_pos='140',
+                            description='SEQ_MISMATCH_PSP_UP',
+                            gene_name='H2AFX')
+
+def test_sl6a3_t53():
+    pm = ProtMapper()
+    motif, site_pos = pm.map_to_human_ref('Q01959', 'uniprot', 'T', '53')
+    assert ms == MappedSite(up_id='Q01959', valid=False, orig_res='T',
+                            orig_pos='53', mapped_res='S', mapped_pos='53',
+                            description='INFERRED_WRONG_RESIDUE',
+                            gene_name='Q01959')
+
+
+def test_smpd1_s508():
+    # S508 is invalid, should be mapped to S510
+    pm = ProtMapper()
+    motif, site_pos = pm.map_to_human_ref('P17405', 'uniprot', 'S', '508')
+    assert ms == MappedSite(up_id='P17405', valid=False, orig_res='S',
+                            orig_pos='508', mapped_res='S', mapped_pos='510',
+                            description='INFERRED_ALTERNATIVE_ISOFORM',
+                            gene_name='SMPD1')
+
+
+def test_set_s9():
+    # S508 is invalid, should be mapped to S510
+    pm = ProtMapper()
+    motif, site_pos = pm.map_to_human_ref('Q01105', 'uniprot', 'S', '9')
+    assert ms == MappedSite(up_id='Q01105', valid=False, orig_res='S',
+                            orig_pos='9', mapped_res='S', mapped_pos='9',
+                            description='INFERRED_ALTERNATIVE_ISOFORM',
+                            gene_name='SMPD1')
+
+
 def test_repr_str():
     sm = ProtMapper()
     ms = sm.map_to_human_ref('MAPK1', 'hgnc', 'T', '183')

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -194,10 +194,21 @@ def test_h2afx_s139():
     ms = pm.map_to_human_ref('P16104', 'uniprot', 'S', '139')
     assert ms == MappedSite(up_id='P16104', valid=False, orig_res='S',
                             orig_pos='139', mapped_res='S', mapped_pos='140',
-                            description='SEQ_MISMATCH_PSP_UP',
+                            description='REMAPPED_FROM_PSP_SEQUENCE',
                             gene_name='H2AFX')
 
 
+def test_myl9_s19():
+    pm = ProtMapper()
+    ms = pm.map_to_human_ref('P24844', 'uniprot', 'S', '19')
+    assert ms == MappedSite(up_id='P24844', error_code=None, valid=False,
+                            orig_res='S', orig_pos='19', mapped_res='S',
+                            mapped_pos='20',
+                            description='INFERRED_METHIONINE_CLEAVAGE',
+                            gene_name='MYL9')
+
+
+"""
 def test_sl6a3_t53():
     pm = ProtMapper()
     ms = pm.map_to_human_ref('Q01959', 'uniprot', 'T', '53')
@@ -205,7 +216,7 @@ def test_sl6a3_t53():
                             orig_pos='53', mapped_res='S', mapped_pos='53',
                             description='INFERRED_WRONG_RESIDUE',
                             gene_name='SLC6A3')
-
+"""
 
 def test_smpd1_s508():
     pm = ProtMapper()
@@ -225,6 +236,19 @@ def test_set_s9():
                             mapped_res='S', mapped_pos='9',
                             description='ISOFORM_SPECIFIC_SITE',
                             gene_name='SET')
+"""
+
+
+"""
+def test_remapping_non_human():
+    # No mapping (sequence differs)
+    pm = ProtMapper()
+    ms = pm.map_to_human_ref('P42261', 'uniprot', 'S', '881')
+    assert ms == MappedSite(up_id='P42261', valid=False, orig_res='S',
+                            orig_pos='881', mapped_id='P23818',
+                            mapped_res='S', mapped_pos='881',
+                            description='NON_HUMAN_SITE',
+                            gene_name='GRIA1')
 """
 
 def test_repr_str():
@@ -367,5 +391,3 @@ def test_peptide_round_trip():
                             description=None,
                             gene_name='MAPK1')
 
-if __name__ == '__main__':
-    test_sl6a3_t53()

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -227,7 +227,6 @@ def test_smpd1_s508():
                             gene_name='SMPD1')
 
 
-"""
 def test_set_s9():
     pm = ProtMapper()
     ms = pm.map_to_human_ref('Q01105', 'uniprot', 'S', '9')
@@ -236,7 +235,6 @@ def test_set_s9():
                             mapped_res='S', mapped_pos='9',
                             description='ISOFORM_SPECIFIC_SITE',
                             gene_name='SET')
-"""
 
 
 """

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -198,15 +198,14 @@ def test_h2afx_s139():
                             gene_name='H2AFX')
 
 
-"""
 def test_sl6a3_t53():
     pm = ProtMapper()
     ms = pm.map_to_human_ref('Q01959', 'uniprot', 'T', '53')
     assert ms == MappedSite(up_id='Q01959', valid=False, orig_res='T',
                             orig_pos='53', mapped_res='S', mapped_pos='53',
                             description='INFERRED_WRONG_RESIDUE',
-                            gene_name='SL6A3')
-"""
+                            gene_name='SLC6A3')
+
 
 def test_smpd1_s508():
     pm = ProtMapper()
@@ -369,4 +368,4 @@ def test_peptide_round_trip():
                             gene_name='MAPK1')
 
 if __name__ == '__main__':
-    test_h2afx_s139()
+    test_sl6a3_t53()

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -207,7 +207,6 @@ def test_sl6a3_t53():
 
 
 def test_smpd1_s508():
-    # S508 is invalid, should be mapped to S510
     pm = ProtMapper()
     motif, site_pos = pm.map_to_human_ref('P17405', 'uniprot', 'S', '508')
     assert ms == MappedSite(up_id='P17405', valid=False, orig_res='S',
@@ -217,13 +216,12 @@ def test_smpd1_s508():
 
 
 def test_set_s9():
-    # S508 is invalid, should be mapped to S510
     pm = ProtMapper()
     motif, site_pos = pm.map_to_human_ref('Q01105', 'uniprot', 'S', '9')
     assert ms == MappedSite(up_id='Q01105', valid=False, orig_res='S',
                             orig_pos='9', mapped_res='S', mapped_pos='9',
                             description='INFERRED_ALTERNATIVE_ISOFORM',
-                            gene_name='SMPD1')
+                            gene_name='SET')
 
 
 def test_repr_str():

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -223,7 +223,7 @@ def test_smpd1_s508():
     ms = pm.map_to_human_ref('P17405', 'uniprot', 'S', '508')
     assert ms == MappedSite(up_id='P17405', valid=False, orig_res='S',
                             orig_pos='508', mapped_res='S', mapped_pos='510',
-                            description='SEQ_MISMATCH_PSP_UP',
+                            description='REMAPPED_FROM_PSP_SEQUENCE',
                             gene_name='SMPD1')
 
 

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -36,11 +36,13 @@ def test_validate_site():
 
 def test_mapped_site_equals():
     ms1 = MappedSite(up_id='P28482', error_code=None, valid=False, orig_res='T',
-                     orig_pos='183', mapped_res='T', mapped_pos='185',
-                     description='INFERRED_MOUSE_SITE', gene_name='MAPK1')
+                     orig_pos='183', mapped_id='P28482', mapped_res='T',
+                     mapped_pos='185', description='INFERRED_MOUSE_SITE',
+                     gene_name='MAPK1')
     ms2 = MappedSite(up_id='P28482', valid=False, orig_res='T',
-                     orig_pos='183', mapped_res='T', mapped_pos='185',
-                     description='INFERRED_MOUSE_SITE', gene_name='MAPK1')
+                     orig_pos='183', mapped_id='P28482', mapped_res='T',
+                     mapped_pos='185', description='INFERRED_MOUSE_SITE',
+                     gene_name='MAPK1')
     assert ms1 == ms2
     ms2.gene_name = 'FOO'
     assert ms1 != ms2
@@ -52,11 +54,13 @@ def test_mapped_site_equals():
 
 def test_mapped_site_hash():
     ms1 = MappedSite(up_id='P28482', error_code=None, valid=False, orig_res='T',
-                     orig_pos='183', mapped_res='T', mapped_pos='185',
-                     description='INFERRED_MOUSE_SITE', gene_name='MAPK1')
+                     orig_pos='183', mapped_id='P28482', mapped_res='T',
+                     mapped_pos='185', description='INFERRED_MOUSE_SITE',
+                     gene_name='MAPK1')
     ms2 = MappedSite(up_id='P28482', error_code=None, valid=False, orig_res='T',
-                     orig_pos='183', mapped_res='T', mapped_pos='185',
-                     description='INFERRED_MOUSE_SITE', gene_name='MAPK1')
+                     orig_pos='183', mapped_id='P28482', mapped_res='T',
+                     mapped_pos='185', description='INFERRED_MOUSE_SITE',
+                     gene_name='MAPK1')
     assert hash(ms1) == hash(ms2)
     ms2.gene_name = 'FOO'
     assert hash(ms1) != hash(ms2)
@@ -66,11 +70,13 @@ def test_mapped_site_set_ctr():
     """Check if two identical sites in different objects are handled as equal
     in sets and counters."""
     ms1 = MappedSite(up_id='P28482', error_code=None, valid=False, orig_res='T',
-                     orig_pos='183', mapped_res='T', mapped_pos='185',
-                     description='INFERRED_MOUSE_SITE', gene_name='MAPK1')
+                     orig_pos='183', mapped_id='P28482', mapped_res='T',
+                     mapped_pos='185', description='INFERRED_MOUSE_SITE',
+                     gene_name='MAPK1')
     ms2 = MappedSite(up_id='P28482', error_code=None, valid=False, orig_res='T',
-                     orig_pos='183', mapped_res='T', mapped_pos='185',
-                     description='INFERRED_MOUSE_SITE', gene_name='MAPK1')
+                     orig_pos='183', mapped_id='P28482', mapped_res='T',
+                     mapped_pos='185', description='INFERRED_MOUSE_SITE',
+                     gene_name='MAPK1')
     ms_list = [ms1, ms2]
     assert len(set(ms_list)) == 1
     ctr = Counter(ms_list)
@@ -114,16 +120,17 @@ def test_check_agent_mod_up_id():
     sm = ProtMapper()
     ms = sm.map_to_human_ref('P28482', 'uniprot', 'T', '185')
     assert ms == MappedSite(up_id='P28482', error_code=None, valid=True,
-                            orig_res='T', orig_pos='185', mapped_res=None,
-                            mapped_pos=None, description='VALID',
-                            gene_name='MAPK1')
+                            orig_res='T', orig_pos='185', mapped_id=None,
+                            mapped_res=None, mapped_pos=None,
+                            description='VALID', gene_name='MAPK1')
     assert ms.not_invalid() is True
     assert ms.has_mapping() is False
 
     ms = sm.map_to_human_ref('P28482', 'uniprot', 'T', '183')
     assert ms == MappedSite(up_id='P28482', error_code=None, valid=False,
-                            orig_res='T', orig_pos='183', mapped_res='T',
-                            mapped_pos='185', description='INFERRED_MOUSE_SITE',
+                            orig_res='T', orig_pos='183', mapped_id='P28482',
+                            mapped_res='T', mapped_pos='185',
+                            description='INFERRED_MOUSE_SITE',
                             gene_name='MAPK1')
     assert ms.not_invalid() is False
     assert ms.has_mapping() is True
@@ -133,14 +140,15 @@ def test_check_agent_mod_hgnc():
     sm = ProtMapper()
     ms = sm.map_to_human_ref('MAPK1', 'hgnc', 'T', '185')
     assert ms == MappedSite(up_id='P28482', error_code=None, valid=True,
-                            orig_res='T', orig_pos='185', mapped_res=None,
-                            mapped_pos=None, description='VALID',
-                            gene_name='MAPK1')
+                            orig_res='T', orig_pos='185', mapped_id=None,
+                            mapped_res=None, mapped_pos=None,
+                            description='VALID', gene_name='MAPK1')
 
     ms = sm.map_to_human_ref('MAPK1', 'hgnc', 'T', '183')
     assert ms == MappedSite(up_id='P28482', error_code=None, valid=False,
-                            orig_res='T', orig_pos='183', mapped_res='T',
-                            mapped_pos='185', description='INFERRED_MOUSE_SITE',
+                            orig_res='T', orig_pos='183', mapped_id='P28482',
+                            mapped_res='T', mapped_pos='185',
+                            description='INFERRED_MOUSE_SITE',
                             gene_name='MAPK1')
 
 
@@ -148,7 +156,8 @@ def test_map_mouse_site():
     sm = ProtMapper()
     ms = sm.map_to_human_ref('THEMIS2', 'hgnc', 'Y', '660')
     assert ms == MappedSite(up_id='Q5TEJ8', error_code=None, valid=False,
-                            orig_res='Y', orig_pos='660', mapped_res='Y',
+                            orig_res='Y', orig_pos='660', mapped_id='Q5TEJ8',
+                            mapped_res='Y',
                             mapped_pos='632', description='INFERRED_MOUSE_SITE',
                             gene_name='THEMIS2')
 
@@ -157,17 +166,17 @@ def test_map_rat_site():
     sm = ProtMapper()
     ms = sm.map_to_human_ref('NPHS1', 'hgnc', 'Y', '1204')
     assert ms == MappedSite(up_id='O60500', error_code=None, valid=False,
-                            orig_res='Y', orig_pos='1204', mapped_res='Y',
-                            mapped_pos='1193', description='INFERRED_RAT_SITE',
-                            gene_name='NPHS1')
+                            orig_res='Y', orig_pos='1204', mapped_id='O60500',
+                            mapped_res='Y', mapped_pos='1193',
+                            description='INFERRED_RAT_SITE', gene_name='NPHS1')
 
 
 def test_map_methionine_cleavage():
     sm = ProtMapper()
     ms = sm.map_to_human_ref('DAXX', 'hgnc', 'S', '667')
     assert ms == MappedSite(up_id='Q9UER7', error_code=None, valid=False,
-                            orig_res='S', orig_pos='667', mapped_res='S',
-                            mapped_pos='668',
+                            orig_res='S', orig_pos='667', mapped_id='Q9UER7',
+                            mapped_res='S', mapped_pos='668',
                             description='INFERRED_METHIONINE_CLEAVAGE',
                             gene_name='DAXX')
 
@@ -176,7 +185,8 @@ def test_map_from_sitemap():
     sm = ProtMapper()
     ms = sm.map_to_human_ref('P15056', 'uniprot', 'S', '753')
     assert ms == MappedSite(up_id='P15056', valid=False, orig_res='S',
-                            orig_pos='753', mapped_res='T', mapped_pos='753',
+                            orig_pos='753', mapped_id='P15056',
+                            mapped_res='T', mapped_pos='753',
                             description='wrong residue', gene_name='BRAF')
 
 
@@ -184,7 +194,8 @@ def test_map_invalid_from_sitemap():
     sm = ProtMapper()
     ms = sm.map_to_human_ref('P06400', 'uniprot', 'D', '1')
     assert ms == MappedSite(up_id='P06400', valid=False, orig_res='D',
-                            orig_pos='1', mapped_res=None, mapped_pos=None,
+                            orig_pos='1', mapped_id='P06400',
+                            mapped_res=None, mapped_pos=None,
                             description='probable reading error: cyclin D1',
                             gene_name='RB1')
 
@@ -193,7 +204,8 @@ def test_h2afx_s139():
     pm = ProtMapper()
     ms = pm.map_to_human_ref('P16104', 'uniprot', 'S', '139')
     assert ms == MappedSite(up_id='P16104', valid=False, orig_res='S',
-                            orig_pos='139', mapped_res='S', mapped_pos='140',
+                            orig_pos='139', mapped_id='P16104',
+                            mapped_res='S', mapped_pos='140',
                             description='REMAPPED_FROM_PSP_SEQUENCE',
                             gene_name='H2AFX')
 
@@ -202,8 +214,8 @@ def test_myl9_s19():
     pm = ProtMapper()
     ms = pm.map_to_human_ref('P24844', 'uniprot', 'S', '19')
     assert ms == MappedSite(up_id='P24844', error_code=None, valid=False,
-                            orig_res='S', orig_pos='19', mapped_res='S',
-                            mapped_pos='20',
+                            orig_res='S', orig_pos='19', mapped_id='P24844',
+                            mapped_res='S', mapped_pos='20',
                             description='INFERRED_METHIONINE_CLEAVAGE',
                             gene_name='MYL9')
 
@@ -222,7 +234,8 @@ def test_smpd1_s508():
     pm = ProtMapper()
     ms = pm.map_to_human_ref('P17405', 'uniprot', 'S', '508')
     assert ms == MappedSite(up_id='P17405', valid=False, orig_res='S',
-                            orig_pos='508', mapped_res='S', mapped_pos='510',
+                            orig_pos='508', mapped_id='P17405',
+                            mapped_res='S', mapped_pos='510',
                             description='REMAPPED_FROM_PSP_SEQUENCE',
                             gene_name='SMPD1')
 
@@ -254,6 +267,7 @@ def test_repr_str():
     ms = sm.map_to_human_ref('MAPK1', 'hgnc', 'T', '183')
     assert str(ms) == ("MappedSite(up_id='P28482', error_code=None, "
                        "valid=False, orig_res='T', orig_pos='183', "
+                       "mapped_id='P28482', "
                        "mapped_res='T', mapped_pos='185', "
                        "description='INFERRED_MOUSE_SITE', "
                        "gene_name='MAPK1')")
@@ -272,8 +286,8 @@ def test_write_cache():
     assert len(cache_dict) == 1
     ms = cache_dict[('P28482', 'T', '183')]
     assert ms == MappedSite(up_id='P28482', error_code=None, valid=False,
-                            orig_res='T', orig_pos='183', mapped_res='T',
-                            mapped_pos='185',
+                            orig_res='T', orig_pos='183', mapped_id='P28482',
+                            mapped_res='T', mapped_pos='185',
                             description='INFERRED_MOUSE_SITE',
                             gene_name='MAPK1')
     os.unlink(cache_path)
@@ -281,8 +295,8 @@ def test_write_cache():
 
 def test_mapped_site_to_json():
     kwargs = dict(up_id='P28482', error_code=None, valid=True, orig_res='T',
-                orig_pos='185', mapped_res='T', mapped_pos='185',
-                description='VALID', gene_name='MAPK1')
+                orig_pos='185', mapped_id='P28482', mapped_res='T',
+                mapped_pos='185', description='VALID', gene_name='MAPK1')
     ms = MappedSite(**kwargs)
     assert ms.to_json() == kwargs
 
@@ -295,8 +309,8 @@ def test_invalid_uniprot_http_error():
     assert ms.error_code == 'UNIPROT_HTTP_NOT_FOUND'
     assert ms == MappedSite(up_id='ASDF', error_code='UNIPROT_HTTP_NOT_FOUND',
                    valid=None, orig_res='Q', orig_pos='999',
-                   mapped_res=None, mapped_pos=None, description=None,
-                   gene_name=None)
+                   mapped_id=None, mapped_res=None, mapped_pos=None,
+                   description=None, gene_name=None)
 
 
 def test_invalid_gene_name_error():
@@ -304,7 +318,7 @@ def test_invalid_gene_name_error():
     ms = sm.map_to_human_ref('ASDF', 'hgnc', 'Q', '999')
     assert ms.error_code == 'NO_UNIPROT_ID'
     assert ms == MappedSite(up_id=None, error_code='NO_UNIPROT_ID',
-                   valid=None, orig_res='Q', orig_pos='999',
+                   valid=None, orig_res='Q', orig_pos='999', mapped_id=None,
                    mapped_res=None, mapped_pos=None, description=None,
                    gene_name='ASDF')
 
@@ -355,10 +369,9 @@ def test_map_peptide_to_human_ref():
     ms = sm.map_peptide_to_human_ref('Q04637', 'uniprot', peptide, pos)
     assert isinstance(ms, MappedSite)
     assert ms == MappedSite(up_id='Q04637', error_code=None, valid=True,
-                            orig_res=None, orig_pos=None, mapped_res='S',
-                            mapped_pos='45',
-                            description=None,
-                            gene_name='EIF4G1')
+                            orig_res=None, orig_pos=None, mapped_id='Q04637',
+                            mapped_res='S', mapped_pos='45',
+                            description=None, gene_name='EIF4G1')
     # The same as above except with the gene name instead
     ms2 = sm.map_peptide_to_human_ref('EIF4G1', 'hgnc', peptide, pos)
     assert ms2 == ms
@@ -371,8 +384,8 @@ def test_map_peptide_to_human_ref2():
     sitepos = 7
     ms = pm.map_peptide_to_human_ref(up_id, 'uniprot', peptide, sitepos)
     assert ms == MappedSite(up_id='P07942', error_code=None, valid=True,
-                            orig_res=None, orig_pos=None, mapped_res='S',
-                            mapped_pos='250', description=None,
+                            orig_res=None, orig_pos=None, mapped_id='P07942',
+                            mapped_res='S', mapped_pos='250', description=None,
                             gene_name='LAMB1')
     assert ms
 
@@ -384,8 +397,7 @@ def test_peptide_round_trip():
     ms = pm.map_peptide_to_human_ref('MAPK1', 'hgnc', motif, site_pos)
     assert isinstance(ms, MappedSite)
     assert ms == MappedSite(up_id='P28482', error_code=None, valid=True,
-                            orig_res=None, orig_pos=None, mapped_res='Y',
-                            mapped_pos='187',
-                            description=None,
-                            gene_name='MAPK1')
+                            orig_res=None, orig_pos=None, mapped_id='P28482',
+                            mapped_res='Y', mapped_pos='187',
+                            description=None, gene_name='MAPK1')
 


### PR DESCRIPTION
Adds a feature to account for discrepancies between Uniprot and PSP sequences where the mapped site returned was valid in PSP but not in Uniprot. Calls to the phosphosite_client in the ProtMapper are now refactored into a function `get_psp_mapping` that checks if the site returned from PSP is valid in Uniprot, and if not, uses the peptide information from PSP to re-map it to the human reference sequence.

In addition, the PR includes a feature to identify cases where the site that is queried is valid in a human protein but only in an isoform and *not* in the reference sequence. In these cases the isoform-specific Uniprot ID is returned as part of the mapping and the code `ISOFORM_SPECIFIC_SITE` is used. Note that this is done only for sites that are unique to human isoforms, not for sites unique to mouse/rat proteins or their isoforms. In these cases the function will still return `NO_MAPPING_FOUND`.