### PR TITLE
Implement mapping based on signal peptides

### DIFF
--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -362,8 +362,28 @@ class ProtMapper(object):
                                      gene_name=gene_name)
             self._cache[site_key] = mapped_site
             return mapped_site
-        # ...there's no manually curated site, so do mapping via PhosphoSite
-        # if the data is available:
+
+        # There is no manual mapping, next we try to see if UniProt
+        # reports a signal peptide that could be responsible for the position
+        # being shifted
+        signal_peptide = uniprot_client.get_signal_peptide(up_id)
+        # If there is valid signal peptide information from UniProt
+        if signal_peptide and signal_peptide[0] == 1:
+            # The end position of the signal peptide
+            sp_end_pos = signal_peptide[1]
+            mapped_pos = str(int(position) + sp_end_pos)
+            mapped_res = residue
+            site_valid = uniprot_client.verify_location(up_id, mapped_res,
+                                                        mapped_pos)
+            if site_valid:
+                return MappedSite(up_id, False, residue, position,
+                                  mapped_id=up_id,
+                                  mapped_res=mapped_res,
+                                  mapped_pos=mapped_pos,
+                                  description='SIGNAL_PEPTIDE_REMOVED',
+                                  gene_name=gene_name)
+        # ...there's no manually curated site or signal peptide, so do mapping
+        # via PhosphoSite if the data is available:
         human_prot = uniprot_client.is_human(up_id)
         if phosphosite_client.has_data():
             # First, look for other entries in phosphosite for this protein

--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -368,20 +368,22 @@ class ProtMapper(object):
         # being shifted
         signal_peptide = uniprot_client.get_signal_peptide(up_id)
         # If there is valid signal peptide information from UniProt
-        if signal_peptide and signal_peptide[0] == 1:
+        if signal_peptide and signal_peptide[0] == 1 and \
+                signal_peptide[1] is not None:
             # The end position of the signal peptide
             sp_end_pos = signal_peptide[1]
-            mapped_pos = str(int(position) + sp_end_pos)
-            mapped_res = residue
-            site_valid = uniprot_client.verify_location(up_id, mapped_res,
-                                                        mapped_pos)
-            if site_valid:
-                return MappedSite(up_id, False, residue, position,
-                                  mapped_id=up_id,
-                                  mapped_res=mapped_res,
-                                  mapped_pos=mapped_pos,
-                                  description='SIGNAL_PEPTIDE_REMOVED',
-                                  gene_name=gene_name)
+            if sp_end_pos is not None:
+                mapped_pos = str(int(position) + sp_end_pos)
+                mapped_res = residue
+                site_valid = uniprot_client.verify_location(up_id, mapped_res,
+                                                            mapped_pos)
+                if site_valid:
+                    return MappedSite(up_id, False, residue, position,
+                                      mapped_id=up_id,
+                                      mapped_res=mapped_res,
+                                      mapped_pos=mapped_pos,
+                                      description='SIGNAL_PEPTIDE_REMOVED',
+                                      gene_name=gene_name)
         # ...there's no manually curated site or signal peptide, so do mapping
         # via PhosphoSite if the data is available:
         human_prot = uniprot_client.is_human(up_id)

--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -366,7 +366,7 @@ class ProtMapper(object):
         # There is no manual mapping, next we try to see if UniProt
         # reports a signal peptide that could be responsible for the position
         # being shifted
-        signal_peptide = uniprot_client.get_signal_peptide(up_id)
+        signal_peptide = uniprot_client.get_signal_peptide(up_id, False)
         # If there is valid signal peptide information from UniProt
         if signal_peptide and signal_peptide[0] == 1 and \
                 signal_peptide[1] is not None:

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -47,6 +47,7 @@ def _download_ftp_gz(ftp_host, ftp_path, out_file=None, ftp_blocksize=33554432):
             f.write(ret)
     return ret
 
+
 def download_phosphositeplus(out_file, cached=True):
     logger.info("Note that PhosphoSitePlus data is not available for "
                 "commercial use; please see full terms and conditions at: "
@@ -59,11 +60,14 @@ def download_uniprot_entries(out_file, cached=True):
         _download_from_s3('uniprot_entries.tsv', out_file)
         return
 
+    columns = ['id', 'genes(PREFERRED)', 'entry%20name', 'database(RGD)',
+               'database(MGI)', 'length', 'reviewed', 'feature(SIGNAL)']
+    columns_str = ','.join(columns)
+
     logger.info('Downloading UniProt entries')
     url = 'http://www.uniprot.org/uniprot/?' + \
         'sort=id&desc=no&compress=no&query=reviewed:yes&' + \
-        'format=tab&columns=id,genes(PREFERRED),' + \
-        'entry%20name,database(RGD),database(MGI),length,reviewed'
+        'format=tab&columns=' + columns_str
     logger.info('Downloading %s' % url)
     res = requests.get(url)
     if res.status_code != 200:
@@ -73,8 +77,7 @@ def download_uniprot_entries(out_file, cached=True):
     url = 'http://www.uniprot.org/uniprot/?' + \
         'sort=id&desc=no&compress=no&query=reviewed:no&fil=organism:' + \
         '%22Homo%20sapiens%20(Human)%20[9606]%22&' + \
-        'format=tab&columns=id,genes(PREFERRED),entry%20name,' + \
-        'database(RGD),database(MGI),length,reviewed'
+        'format=tab&columns=' + columns_str
     logger.info('Downloading %s' % url)
     res = requests.get(url)
     if res.status_code != 200:

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -433,3 +433,13 @@ def test_manual_vs_methionine():
             description='numbering after 24-residue signaling peptide removed',
             gene_name='EGFR')
 
+
+def test_signal_peptide():
+    pm = ProtMapper()
+    ms = pm.map_to_human_ref('P04626', 'uniprot', 'Y', '1226')
+    assert isinstance(ms, MappedSite)
+    assert ms == MappedSite(up_id='P04626', error_code=None, valid=False,
+                            orig_res='Y', orig_pos='1226', mapped_id='P04626',
+                            mapped_res='Y', mapped_pos='1248',
+                            description='SIGNAL_PEPTIDE_REMOVED',
+                            gene_name='ERBB2'), ms

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -443,3 +443,8 @@ def test_signal_peptide():
                             mapped_res='Y', mapped_pos='1248',
                             description='SIGNAL_PEPTIDE_REMOVED',
                             gene_name='ERBB2'), ms
+
+
+def test_signal_peptide_no_error():
+    pm = ProtMapper()
+    ms = pm.map_to_human_ref('Q9RI12', 'uniprot', 'S', '38')

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -246,7 +246,7 @@ def test_set_s9():
     assert ms == MappedSite(up_id='Q01105', valid=False, orig_res='S',
                             orig_pos='9', mapped_id='Q01105-2',
                             mapped_res='S', mapped_pos='9',
-                            description='ISOFORM_SPECIFIC_SITE',
+                            description='INFERRED_ALTERNATIVE_ISOFORM',
                             gene_name='SET')
 
 
@@ -417,7 +417,7 @@ def test_tau_sites():
     assert ms == MappedSite(up_id='P10636', error_code=None, valid=False,
                             orig_res='T', orig_pos='153', mapped_id='P10636-8',
                             mapped_res='T', mapped_pos='153',
-                            description='ISOFORM_SPECIFIC_SITE',
+                            description='INFERRED_ALTERNATIVE_ISOFORM',
                             gene_name='MAPT')
 
 
@@ -448,3 +448,14 @@ def test_signal_peptide():
 def test_signal_peptide_no_error():
     pm = ProtMapper()
     ms = pm.map_to_human_ref('Q9RI12', 'uniprot', 'S', '38')
+
+
+def test_egfr_mouse_1068_to_human_1092():
+    pm = ProtMapper()
+    ms = pm.map_to_human_ref('Q01279', 'uniprot', 'Y', '1068')
+    assert ms == MappedSite(up_id='Q01279', error_code=None, valid=False,
+            orig_res='Y', orig_pos='1068', mapped_id='P00533',
+            mapped_res='Y', mapped_pos='1092',
+            description='SIGNAL_PEPTIDE_REMOVED',
+            gene_name='Egfr')
+

--- a/protmapper/tests/test_uniprot_client.py
+++ b/protmapper/tests/test_uniprot_client.py
@@ -173,14 +173,17 @@ def test_rat_from_human():
 def test_length():
     assert uniprot_client.get_length('P15056') == 766
 
+
 @attr('webservice')
 def test_get_function():
     fun = uniprot_client.get_function('P15056')
     assert fun.startswith('Protein kinase involved in the transduction')
 
+
 def test_get_is_reviewed():
     assert not uniprot_client.is_reviewed('V9HWD6')
     assert uniprot_client.is_reviewed('P31946-1')
+
 
 def test_get_ids_from_refseq():
     up_ids = uniprot_client.get_ids_from_refseq('NP_003395.1')
@@ -189,3 +192,12 @@ def test_get_ids_from_refseq():
                                                 reviewed_only=True)
     assert up_ids == ['P31946-1']
 
+
+@attr('webservice')
+def test_get_signal_peptide():
+    bp, ep = uniprot_client.get_signal_peptide('P00533')
+    assert bp == 1, bp
+    assert ep == 24, ep
+    bp, ep = uniprot_client.get_signal_peptide('P00534')
+    assert bp is None, bp
+    assert ep is None, ep

--- a/protmapper/tests/test_uniprot_client.py
+++ b/protmapper/tests/test_uniprot_client.py
@@ -195,9 +195,15 @@ def test_get_ids_from_refseq():
 
 @attr('webservice')
 def test_get_signal_peptide():
+    # This is a valid entry local to the resource file
     bp, ep = uniprot_client.get_signal_peptide('P00533')
     assert bp == 1, bp
     assert ep == 24, ep
+    # This one requires a web lookup
     bp, ep = uniprot_client.get_signal_peptide('P00534')
+    assert bp is None, bp
+    assert ep is None, ep
+    # This one errors when doing web lookup
+    bp, ep = uniprot_client.get_signal_peptide('Q9H7H1')
     assert bp is None, bp
     assert ep is None, ep

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -719,7 +719,7 @@ def get_function(protein_id):
     return function.text
 
 
-def get_signal_peptide(protein_id):
+def get_signal_peptide(protein_id, web_fallback=True):
     """Return the position of a signal peptide for the given protein.
 
     Parameters
@@ -727,6 +727,9 @@ def get_signal_peptide(protein_id):
     protein_id : str
         The UniProt ID of the protein whose signal peptide position
         is to be returned.
+    web_fallback : Optional[bool]
+        If True the UniProt web service is used to download information when
+        the local resource file doesn't contain the right information.
 
     Returns
     -------
@@ -736,7 +739,7 @@ def get_signal_peptide(protein_id):
     """
     # Note, we use False here to differentiate from None
     entry = um.signal_peptide.get(protein_id, False)
-    if entry is not False:
+    if entry is not False or not web_fallback:
         return entry
     et = query_protein_xml(protein_id)
     if et is None:
@@ -949,12 +952,14 @@ def _build_uniprot_entries():
                 if rgd_ids:
                     uniprot_rgd[up_id] = rgd_ids[0]
                     uniprot_rgd_reverse[rgd_ids[0]] = up_id
+            uniprot_signal_peptide[up_id] = (None, None)
             if signal_peptide:
                 match = re.match(r'SIGNAL (\d+) (\d+) ', signal_peptide)
                 if match:
                     beg_pos, end_pos = match.groups()
                     uniprot_signal_peptide[up_id] = \
                         (int(beg_pos), int(end_pos))
+
     return (uniprot_gene_name, uniprot_mnemonic, uniprot_mnemonic_reverse,
             uniprot_mgi, uniprot_rgd, uniprot_mgi_reverse, uniprot_rgd_reverse,
             uniprot_length, uniprot_reviewed, uniprot_signal_peptide)

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -714,6 +714,20 @@ def get_function(protein_id):
 
 
 def get_signal_peptide(protein_id):
+    """Return the position of a signal peptide for the given protein.
+
+    Parameters
+    ----------
+    protein_id : str
+        The UniProt ID of the protein whose signal peptide position
+        is to be returned.
+
+    Returns
+    -------
+    tuple of int
+        THe beginning and end position of the signal peptide as a tuple
+        of integers.
+    """
     et = query_protein_xml(protein_id)
     location = et.find(
         'up:entry/up:feature[@type="signal peptide"]/up:location',
@@ -724,13 +738,32 @@ def get_signal_peptide(protein_id):
         begin = location.find('up:begin', namespaces=xml_ns)
         if begin is not None:
             begin_pos = begin.attrib.get('position')
+            if begin_pos is not None:
+                begin_pos = int(begin_pos)
         end = location.find('up:end', namespaces=xml_ns)
         if end is not None:
             end_pos = end.attrib.get('position')
+            if end_pos is not None:
+                end_pos = int(end_pos)
     return begin_pos, end_pos
 
 
 def get_ids_from_refseq(refseq_id, reviewed_only=False):
+    """Return UniProt IDs from a RefSeq ID".
+
+    Parameters
+    ----------
+    refseq_id : str
+        The RefSeq ID of the protein to map.
+    reviewed_only : Optional[bool]
+        If True, only reviewed UniProt IDs are returned.
+        Default: False
+
+    Returns
+    -------
+    list of str
+        A list of UniProt IDs corresponding to the RefSeq ID.
+    """
     try:
         up_ids = um.refseq_uniprot[refseq_id]
     except KeyError:

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -688,8 +688,11 @@ def query_protein_xml(protein_id):
     except KeyError:
         pass
     url = uniprot_url + protein_id + '.xml'
-    ret = requests.get(url)
-    et = ElementTree.fromstring(ret.content)
+    try:
+        ret = requests.get(url)
+        et = ElementTree.fromstring(ret.content)
+    except Exception as e:
+        return None
     return et
 
 
@@ -707,6 +710,8 @@ def get_function(protein_id):
         The function description of the protein.
     """
     et = query_protein_xml(protein_id)
+    if et is None:
+        return None
     function = et.find('up:entry/up:comment[@type="function"]/up:text',
                        namespaces={'up': 'http://uniprot.org/uniprot'})
     if function is None:
@@ -734,6 +739,8 @@ def get_signal_peptide(protein_id):
     if entry is not False:
         return entry
     et = query_protein_xml(protein_id)
+    if et is None:
+        return None, None
     location = et.find(
         'up:entry/up:feature[@type="signal peptide"]/up:location',
         namespaces=xml_ns)

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -21,6 +21,8 @@ rdf_prefixes = """
     PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
     PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> """
 
+xml_ns = {'up': 'http://uniprot.org/uniprot'}
+
 
 @lru_cache(maxsize=10000)
 def query_protein(protein_id):
@@ -709,6 +711,23 @@ def get_function(protein_id):
     if function is None:
         return None
     return function.text
+
+
+def get_signal_peptide(protein_id):
+    et = query_protein_xml(protein_id)
+    location = et.find(
+        'up:entry/up:feature[@type="signal peptide"]/up:location',
+        namespaces=xml_ns)
+    begin_pos = None
+    end_pos = None
+    if location is not None:
+        begin = location.find('up:begin', namespaces=xml_ns)
+        if begin is not None:
+            begin_pos = begin.attrib.get('position')
+        end = location.find('up:end', namespaces=xml_ns)
+        if end is not None:
+            end_pos = end.attrib.get('position')
+    return begin_pos, end_pos
 
 
 def get_ids_from_refseq(refseq_id, reviewed_only=False):

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -734,7 +734,7 @@ def get_signal_peptide(protein_id, web_fallback=True):
     Returns
     -------
     tuple of int
-        THe beginning and end position of the signal peptide as a tuple
+        The beginning and end position of the signal peptide as a tuple
         of integers.
     """
     # Note, we use False here to differentiate from None


### PR DESCRIPTION
This PR extends the UniProt resource table to include information on signal peptides and implements offline and web-based lookups for signal peptide begin/end positions. This is then used to check if the existence of a signal peptide can explain a shift in the position with respect to the reference sequence, and return a mapping with the SIGNAL_PEPTIDE_REMOVED code when valid.