### PR TITLE
Use version in resource downloads

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ author = 'John A. Bachman, Benjamin M. Gyori'
 # The short X.Y version
 version = '0.0'
 # The full version, including alpha/beta/rc tags
-release = '0.0.6'
+release = '0.0.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/protmapper/__init__.py
+++ b/protmapper/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.6'
+__version__ = '0.0.7'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/protmapper/__init__.py
+++ b/protmapper/__init__.py
@@ -1,3 +1,4 @@
+__version__ = '0.0.6'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -1,13 +1,14 @@
 import os
 import csv
 import zlib
-import logging
-from ftplib import FTP
-from io import BytesIO, StringIO
 import boto3
+import logging
 import requests
 import botocore
+from ftplib import FTP
+from io import BytesIO, StringIO
 from urllib.request import urlretrieve
+from . import __version__
 
 
 logger = logging.getLogger('protmapper.resources')
@@ -15,7 +16,7 @@ logger = logging.getLogger('protmapper.resources')
 
 # If the protmapper resource directory does not exist, try to create it
 home_dir = os.path.expanduser('~')
-resource_dir = os.path.join(home_dir, '.protmapper')
+resource_dir = os.path.join(home_dir, '.protmapper', __version__)
 
 
 if not os.path.isdir(resource_dir):
@@ -162,6 +163,7 @@ def download_refseq_seq(out_file, cached=True):
         return
     else:
         raise NotImplementedError()
+
 
 def download_refseq_uniprot(out_file, cached=True):
     if cached:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def main():
     install_list = ['requests', 'rdflib', 'boto3']
 
     setup(name='protmapper',
-          version='0.0.6',
+          version='0.0.7',
           description='Map protein sites to human reference sequence.',
           long_description=('The protmapper is a tool to map inconsistent '
                             'protein sites (i.e., not matching the human '

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import sys
 from setuptools import setup
 
+
 def main():
     install_list = ['requests', 'rdflib', 'boto3']
 
@@ -26,7 +27,6 @@ def main():
             ],
           keywords=['protein', 'proteomics', 'sequence', 'alignment',
                     'assembly', 'post-translational', 'modification'],
-          #project_urls={'Documentation': 'https://protmapper.readthedocs.io'},
           packages=['protmapper'],
           install_requires=install_list,
           tests_require=['nose'],


### PR DESCRIPTION
This PR makes a simple change to append the version (imported from `__init__`) to the resource path. This allows synchronizing the release versions to versions of resource files cached on S3. 

For non-cached downloads, things will just work without any additional action. For cached downloads to work, any time there is a breaking change to resources, the version can simply be bumped and a new version released (along with a corresponding versioned path on S3). Further, any time a new release is made, a new folder with the cached files needs to be added on S3.