### PR TITLE
Fix handling multiple returned UP IDs for an HGNC ID

### DIFF
--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -698,9 +698,9 @@ def _get_uniprot_id(prot_id, prot_ns):
         # Try to get UniProt ID from HGNC
         up_id = uniprot_ids.get(hgnc_id)
         # If the UniProt ID is a list then choose the first one.
-        if up_id and (not isinstance(up_id, basestring) and
-                      isinstance(up_id[0], basestring)):
-            up_id = up_id[0]
+        parts = up_id.split(', ')
+        if len(parts) > 1:
+            up_id = parts[0]
     return up_id
 
 

--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -7,14 +7,6 @@ from protmapper.resources import resource_dir
 from protmapper import phosphosite_client, uniprot_client
 
 
-# Python 2
-try:
-    basestring
-# Python 3
-except:
-    basestring = str
-
-
 logger = logging.getLogger(__name__)
 
 

--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -4,7 +4,7 @@ from os.path import join, abspath, dirname, isfile
 import pickle
 from nose.tools import raises
 from protmapper.api import ProtMapper, _validate_site, MappedSite, \
-                           InvalidSiteException
+                           InvalidSiteException, _get_uniprot_id
 
 
 @raises(InvalidSiteException)
@@ -459,3 +459,10 @@ def test_egfr_mouse_1068_to_human_1092():
             description='SIGNAL_PEPTIDE_REMOVED',
             gene_name='Egfr')
 
+
+def test_mutliple_up_ids():
+    up_id = _get_uniprot_id('TMPO', 'hgnc')
+    assert up_id == 'P42166'
+    pm = ProtMapper()
+    ms = pm.map_peptide_to_human_ref('TMPO', 'hgnc', 'RKVPRLSEKSVEE', 7)
+    assert ms.up_id == 'P42166'


### PR DESCRIPTION
This PR fixes a bug in which we assumed that uniprot_ids contained a list of strings for one-to-many gene-to-protein mappings, instead, it actually contains a single string with IDs separated by commas. Fixes #16.