### PR TITLE
Add mapping from UP ID directly to HGNC ID

### DIFF
--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -684,11 +684,11 @@ def _get_uniprot_id(prot_id, prot_ns):
     # Otherwise, we get the Uniprot ID from the HGNC name
     elif prot_ns == 'hgnc':
         # Get the HGNC ID
-        hgnc_id = hgnc_ids.get(prot_id)
+        hgnc_id = hgnc_name_to_id.get(prot_id)
         if not hgnc_id:
             return None
         # Try to get UniProt ID from HGNC
-        up_id = uniprot_ids.get(hgnc_id)
+        up_id = hgnc_id_to_up.get(hgnc_id)
         # If the UniProt ID is a list then choose the first one.
         parts = up_id.split(', ')
         if len(parts) > 1:
@@ -706,4 +706,5 @@ default_mapper = ProtMapper(default_site_map)
 information found in resources/curated_site_map.csv'."""
 
 
-hgnc_ids, uniprot_ids = uniprot_client._build_hgnc_mappings()
+hgnc_name_to_id, hgnc_id_to_up, up_to_hgnc_id = \
+     uniprot_client._build_hgnc_mappings()

--- a/protmapper/tests/test_uniprot_client.py
+++ b/protmapper/tests/test_uniprot_client.py
@@ -207,3 +207,13 @@ def test_get_signal_peptide():
     bp, ep = uniprot_client.get_signal_peptide('Q9H7H1')
     assert bp is None, bp
     assert ep is None, ep
+
+
+def test_get_hgnc_id():
+    hgnc_id = uniprot_client.get_hgnc_id('P07305')
+    assert hgnc_id == '4714', hgnc_id
+    # NRXN2: ['P58401', 'Q9P2S2'] 8009
+    hgnc_id = uniprot_client.get_hgnc_id('P58401')
+    assert hgnc_id == '8009', hgnc_id
+    hgnc_id = uniprot_client.get_hgnc_id('Q9P2S2')
+    assert hgnc_id == '8009', hgnc_id

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -792,8 +792,8 @@ def get_ids_from_refseq(refseq_id, reviewed_only=False):
 class UniprotMapper(object):
     def __init__(self):
         self.initialized = False
-        self.initialized_hmr = False
         self.initialized_seq = False
+        self.initialized_hgnc = False
         self.initialized_refseq = False
 
     def initialize(self):
@@ -808,10 +808,11 @@ class UniprotMapper(object):
 
         self.initialized = True
 
-    def initialize_hmr(self):
+    def initialize_hgnc(self):
         self._uniprot_human_mouse, self._uniprot_human_rat = \
             _build_human_mouse_rat()
-        self.initialized_hmr = True
+        _, _, self._uniprot_hgnc = _build_hgnc_mappings()
+        self.initialized_hgnc = True
 
     def initialize_seq(self):
         self._sequences = _build_uniprot_sequences()
@@ -826,6 +827,12 @@ class UniprotMapper(object):
         if not self.initialized:
             self.initialize()
         return self._uniprot_gene_name
+
+    @property
+    def uniprot_hgnc(self):
+        if not self.initialized:
+            self.initialize()
+        return self._uniprot_hgnc
 
     @property
     def uniprot_mnemonic(self):
@@ -883,14 +890,14 @@ class UniprotMapper(object):
 
     @property
     def uniprot_human_mouse(self):
-        if not self.initialized_hmr:
-            self.initialize_hmr()
+        if not self.initialized_hgnc:
+            self.initialize_hgnc()
         return self._uniprot_human_mouse
 
     @property
     def uniprot_human_rat(self):
-        if not self.initialized_hmr:
-            self.initialize_hmr()
+        if not self.initialized_hgnc:
+            self.initialize_hgnc()
         return self._uniprot_human_rat
 
     @property

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -551,6 +551,22 @@ def is_rat(protein_id):
     return _is_organism(protein_id, 'RAT')
 
 
+def get_hgnc_id(protein_id):
+    """Return the HGNC ID given the protein id of a human protein.
+
+    Parameters
+    ----------
+    protein_id : str
+        UniProt ID of the human protein
+
+    Returns
+    -------
+    hgnc_id : str
+        HGNC ID of the human protein
+    """
+    return um.uniprot_hgnc.get(protein_id)
+
+
 def get_mgi_id(protein_id):
     """Return the MGI ID given the protein id of a mouse protein.
 
@@ -831,7 +847,7 @@ class UniprotMapper(object):
     @property
     def uniprot_hgnc(self):
         if not self.initialized:
-            self.initialize()
+            self.initialize_hgnc()
         return self._uniprot_hgnc
 
     @property

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -240,10 +240,6 @@ def get_id_from_mnemonic(uniprot_mnemonic):
 def get_gene_name(protein_id, web_fallback=True):
     """Return the gene name for the given UniProt ID.
 
-    This is an alternative to get_hgnc_name and is useful when
-    HGNC name is not availabe (for instance, when the organism
-    is not homo sapiens).
-
     Parameters
     ----------
     protein_id : str
@@ -1002,18 +998,22 @@ def _build_hgnc_mappings():
         csv_rows = csv.reader(fh, delimiter='\t')
         # Skip the header row
         next(csv_rows)
-        hgnc_ids = {}
-        uniprot_ids = {}
+        hgnc_name_to_id = {}
+        hgnc_id_to_up = {}
+        up_to_hgnc_id = {}
         for row in csv_rows:
             hgnc_id = row[0][5:]
             hgnc_status = row[3]
             if hgnc_status == 'Approved':
                 hgnc_name = row[1]
-                hgnc_ids[hgnc_name] = hgnc_id
+                hgnc_name_to_id[hgnc_name] = hgnc_id
             # Uniprot
             uniprot_id = row[6]
-            uniprot_ids[hgnc_id] = uniprot_id
-    return hgnc_ids, uniprot_ids
+            hgnc_id_to_up[hgnc_id] = uniprot_id
+            uniprot_ids = uniprot_id.split(', ')
+            for upid in uniprot_ids:
+                up_to_hgnc_id[upid] = hgnc_id
+    return hgnc_name_to_id, hgnc_id_to_up, up_to_hgnc_id
 
 
 def _build_uniprot_sec():


### PR DESCRIPTION
Until this PR, mapping in the direction of UP ID to HGNC ID was typically done via the corresponding gene symbol. This PR adds a function to get those mappings directly between the two IDs. This can be useful in a lot of downstream code including INDRA and other applications.