### PR TITLE
Handle isoform suffix in UniProt client

### DIFF
--- a/protmapper/tests/test_protmapper.py
+++ b/protmapper/tests/test_protmapper.py
@@ -247,7 +247,7 @@ def test_set_s9():
                             orig_pos='9', mapped_id='Q01105-2',
                             mapped_res='S', mapped_pos='9',
                             description='INFERRED_ALTERNATIVE_ISOFORM',
-                            gene_name='SET')
+                            gene_name='SET'), ms
 
 
 """

--- a/protmapper/tests/test_uniprot_client.py
+++ b/protmapper/tests/test_uniprot_client.py
@@ -217,3 +217,13 @@ def test_get_hgnc_id():
     assert hgnc_id == '8009', hgnc_id
     hgnc_id = uniprot_client.get_hgnc_id('Q9P2S2')
     assert hgnc_id == '8009', hgnc_id
+
+
+def test_is_mouse():
+    assert uniprot_client.is_mouse('P28028-1') is True
+    assert uniprot_client.is_mouse('P07305') is False
+
+
+def test_is_rat():
+    assert uniprot_client.is_rat('P11345-1') is True
+    assert uniprot_client.is_rat('P28028') is False

--- a/protmapper/tests/test_uniprot_client.py
+++ b/protmapper/tests/test_uniprot_client.py
@@ -187,7 +187,7 @@ def test_get_is_reviewed():
 
 def test_get_ids_from_refseq():
     up_ids = uniprot_client.get_ids_from_refseq('NP_003395.1')
-    assert set(up_ids) == set(['V9HWD6', 'P31946-1'])
+    assert set(up_ids) == {'V9HWD6', 'P31946-1'}, set(up_ids)
     up_ids = uniprot_client.get_ids_from_refseq('NP_003395.1',
                                                 reviewed_only=True)
     assert up_ids == ['P31946-1']

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -458,7 +458,6 @@ def verify_location(protein_id, residue, location):
     True if the given residue is at the given position in the sequence
     corresponding to the given UniProt ID, otherwise False.
     """
-    protein_id = get_primary_id(protein_id)
     seq = get_sequence(protein_id)
     # If we couldn't get the sequence (can happen due to web service hiccups)
     # don't throw the statement away by default
@@ -497,7 +496,6 @@ def verify_modification(protein_id, residue, location=None):
     If location is not given, we only check if there is any residue of the
     given type that is modified.
     """
-    protein_id = get_primary_id(protein_id)
     mods = get_modifications(protein_id)
     mod_locs = [m[1] for m in mods]
     if location:

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -458,7 +458,7 @@ def verify_location(protein_id, residue, location):
     True if the given residue is at the given position in the sequence
     corresponding to the given UniProt ID, otherwise False.
     """
-    protein_id = get_primary_id(_strip_isoform(protein_id))
+    protein_id = get_primary_id(protein_id)
     seq = get_sequence(protein_id)
     # If we couldn't get the sequence (can happen due to web service hiccups)
     # don't throw the statement away by default
@@ -497,7 +497,7 @@ def verify_modification(protein_id, residue, location=None):
     If location is not given, we only check if there is any residue of the
     given type that is modified.
     """
-    protein_id = get_primary_id(_strip_isoform(protein_id))
+    protein_id = get_primary_id(protein_id)
     mods = get_modifications(protein_id)
     mod_locs = [m[1] for m in mods]
     if location:

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -73,6 +73,27 @@ def query_protein(protein_id):
     return g
 
 
+def _strip_isoform(protein_id):
+    return protein_id.split('-')[0]
+
+
+def _split_isoform(protein_id):
+    parts = protein_id.split('-', maxsplit=1)
+    protein_id = parts[0]
+    isoform = None
+    if len(parts) == 2:
+        if re.match(r'\d+', parts[1]):
+            isoform = parts[1]
+    return protein_id, isoform
+
+
+def _reattach_isoform(pid, iso):
+    if iso is not None:
+        return '%s-%s' % (pid, iso)
+    else:
+        return pid
+
+
 def is_secondary(protein_id):
     """Return True if the UniProt ID corresponds to a secondary accession.
 
@@ -85,7 +106,7 @@ def is_secondary(protein_id):
     -------
     True if it is a secondary accessing entry, False otherwise.
     """
-    entry = um.uniprot_sec.get(protein_id)
+    entry = um.uniprot_sec.get(_strip_isoform(protein_id))
     if not entry:
         return False
     return True
@@ -103,11 +124,7 @@ def is_reviewed(protein_id):
     -------
     True if it is a reviewed entry, False otherwise.
     """
-    # If this is an isoform, check to see if the base ID is reviewed
-    # (isoform IDs are not in the ID list)
-    if '-' in protein_id:
-        protein_id = protein_id.split('-')[0]
-    return (protein_id in um.uniprot_reviewed)
+    return _strip_isoform(protein_id) in um.uniprot_reviewed
 
 
 def get_primary_id(protein_id):
@@ -126,30 +143,21 @@ def get_primary_id(protein_id):
         human one is returned. If there are no human primary IDs then the
         first primary found is returned.
     """
-    parts = protein_id.split('-', maxsplit=1)
-    protein_id = parts[0]
-    isoform = None
-    if len(parts) == 2:
-        if re.match(r'\d+', parts[1]):
-            isoform = parts[1]
-    protein_id = [0]
-    primaries = um.uniprot_sec.get(protein_id)
+    base_id, isoform = _split_isoform(protein_id)
+    primaries = um.uniprot_sec.get(base_id)
     if primaries:
         if len(primaries) > 1:
-            logger.debug('More than 1 primary ID for %s.' % protein_id)
+            logger.debug('More than 1 primary ID for %s.' % base_id)
             for primary in primaries:
                 # Often secondary IDs were broken into multiple primary IDs
                 # for different organisms. In this case we return the human
                 # one if it exists.
                 if is_human(primary):
-                    return primary
+                    return _reattach_isoform(primary, isoform)
         # If we haven't returned anything then we just return the
         # first primary id
-        return primaries[0]
-    if isoform:
-        protein_id = '%s-%s' % (protein_id, isoform)
-
-    # If there is not secondary entry the we assume this is a primary entry
+        return _reattach_isoform(primaries[0], isoform)
+    # If there is no secondary entry then we assume this is a primary entry
     return protein_id
 
 
@@ -202,7 +210,7 @@ def get_mnemonic(protein_id, web_fallback=False):
     mnemonic : str
         The UniProt mnemonic corresponding to the given Uniprot ID.
     """
-    protein_id = get_primary_id(protein_id)
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     try:
         mnemonic = um.uniprot_mnemonic[protein_id]
         return mnemonic
@@ -263,7 +271,7 @@ def get_gene_name(protein_id, web_fallback=True):
     gene_name : str
         The gene name corresponding to the given Uniprot ID.
     """
-    protein_id = get_primary_id(protein_id)
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     try:
         gene_name = um.uniprot_gene_name[protein_id]
         # We only get here if the protein_id was in the dict
@@ -310,6 +318,7 @@ def get_gene_synonyms(protein_id):
     synonyms : list[str]
         The list of synonyms of the gene corresponding to the protein
     """
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     g = query_protein(protein_id)
     if g is None:
         return None
@@ -342,6 +351,7 @@ def get_protein_synonyms(protein_id):
     synonyms : list[str]
         The list of synonyms of the protein
     """
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     g = query_protein(protein_id)
     if g is None:
         return None
@@ -370,6 +380,7 @@ def get_synonyms(protein_id):
     synonyms : list[str]
         The list of synonyms of the protein and its associated gene.
     """
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     ret = []
     gene_syms = get_gene_synonyms(protein_id)
     if gene_syms:
@@ -382,12 +393,12 @@ def get_synonyms(protein_id):
 
 @lru_cache(maxsize=10000)
 def get_sequence(protein_id):
+    base, iso = _split_isoform(get_primary_id(protein_id))
     # Try to get the sequence from the downloaded sequence files
-    if '-' in protein_id:
-        base, iso = protein_id.split('-')
-        if iso == '1':
-            protein_id = base
-    protein_id = get_primary_id(protein_id)
+    if iso == '1':
+        protein_id = base
+    else:
+        protein_id = _reattach_isoform(base, iso)
     seq = um.uniprot_sequences.get(protein_id)
     if seq is None:
         url = uniprot_url + '%s.fasta' % protein_id
@@ -400,6 +411,7 @@ def get_sequence(protein_id):
 
 
 def get_modifications(protein_id):
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     g = query_protein(protein_id)
     if g is None:
         return None
@@ -446,6 +458,7 @@ def verify_location(protein_id, residue, location):
     True if the given residue is at the given position in the sequence
     corresponding to the given UniProt ID, otherwise False.
     """
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     seq = get_sequence(protein_id)
     # If we couldn't get the sequence (can happen due to web service hiccups)
     # don't throw the statement away by default
@@ -484,6 +497,7 @@ def verify_modification(protein_id, residue, location=None):
     If location is not given, we only check if there is any residue of the
     given type that is modified.
     """
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     mods = get_modifications(protein_id)
     mod_locs = [m[1] for m in mods]
     if location:
@@ -503,6 +517,7 @@ def verify_modification(protein_id, residue, location=None):
 
 
 def _is_organism(protein_id, organism_suffix):
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     mnemonic = get_mnemonic(protein_id)
     if mnemonic is None:
         return False
@@ -523,6 +538,7 @@ def is_human(protein_id):
     -------
     True if the protein_id corresponds to a human protein, otherwise False.
     """
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     return _is_organism(protein_id, 'HUMAN')
 
 
@@ -538,6 +554,7 @@ def is_mouse(protein_id):
     -------
     True if the protein_id corresponds to a mouse protein, otherwise False.
     """
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     return _is_organism(protein_id, 'MOUSE')
 
 
@@ -553,6 +570,7 @@ def is_rat(protein_id):
     -------
     True if the protein_id corresponds to a rat protein, otherwise False.
     """
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     return _is_organism(protein_id, 'RAT')
 
 
@@ -569,7 +587,7 @@ def get_hgnc_id(protein_id):
     hgnc_id : str
         HGNC ID of the human protein
     """
-    protein_id = get_primary_id(protein_id)
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     return um.uniprot_hgnc.get(protein_id)
 
 
@@ -586,7 +604,7 @@ def get_mgi_id(protein_id):
     mgi_id : str
         MGI ID of the mouse protein
     """
-    protein_id = get_primary_id(protein_id)
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     return um.uniprot_mgi.get(protein_id)
 
 
@@ -603,7 +621,7 @@ def get_rgd_id(protein_id):
     rgd_id : str
         RGD ID of the rat protein
     """
-    protein_id = get_primary_id(protein_id)
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     return um.uniprot_rgd.get(protein_id)
 
 
@@ -652,7 +670,7 @@ def get_mouse_id(human_protein_id):
     mouse_protein_id : str
         The UniProt ID of a mouse protein orthologous to the given human protein
     """
-    protein_id = get_primary_id(human_protein_id)
+    human_protein_id = get_primary_id(_strip_isoform(human_protein_id))
     return um.uniprot_human_mouse.get(human_protein_id)
 
 
@@ -669,7 +687,7 @@ def get_rat_id(human_protein_id):
     rat_protein_id : str
         The UniProt ID of a rat protein orthologous to the given human protein
     """
-    protein_id = get_primary_id(human_protein_id)
+    human_protein_id = get_primary_id(_strip_isoform(human_protein_id))
     return um.uniprot_human_rat.get(human_protein_id)
 
 
@@ -686,7 +704,7 @@ def get_length(protein_id):
     length : int
         The length of the protein in amino acids.
     """
-    protein_id = get_primary_id(protein_id)
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     return um.uniprot_length.get(protein_id)
 
 
@@ -708,11 +726,7 @@ def query_protein_xml(protein_id):
         An ElementTree representation of the XML entry for the
         protein.
     """
-    try:
-        prim_ids = um.uniprot_sec[protein_id]
-        protein_id = prim_ids[0]
-    except KeyError:
-        pass
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     url = uniprot_url + protein_id + '.xml'
     try:
         ret = requests.get(url)
@@ -763,8 +777,8 @@ def get_signal_peptide(protein_id, web_fallback=True):
         The beginning and end position of the signal peptide as a tuple
         of integers.
     """
+    protein_id = get_primary_id(_strip_isoform(protein_id))
     # Note, we use False here to differentiate from None
-    protein_id = get_primary_id(protein_id)
     entry = um.signal_peptide.get(protein_id, False)
     if entry is not False or not web_fallback:
         return entry


### PR DESCRIPTION
This PR adds standardized handling of the isoform suffix in `protmapper.uniprot_client`. For most lookups, we need to make sure that the ID used in dict lookups is the primary base ID so the isoform is stripped and we get the primary ID in case a secondary ID is passed in. In some functions the isoform suffix is reattached after converting the ID to primary.