### PR TITLE
Include taxonomy ID for each protein

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -26,7 +26,7 @@ author = 'John A. Bachman, Benjamin M. Gyori'
 # The short X.Y version
 version = '0.0'
 # The full version, including alpha/beta/rc tags
-release = '0.0.17'
+release = '0.0.19'
 
 
 # -- General configuration ---------------------------------------------------

--- a/protmapper/__init__.py
+++ b/protmapper/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.18'
+__version__ = '0.0.19'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -72,7 +72,7 @@ def download_uniprot_entries(out_file, cached=True):
         _download_from_s3('uniprot_entries.tsv', out_file)
         return
     base_columns = ['id', 'genes(PREFERRED)', 'entry%20name', 'database(RGD)',
-                    'database(MGI)', 'length', 'reviewed']
+                    'database(MGI)', 'length', 'reviewed', 'organism-id']
     feature_types = ['SIGNAL', 'CHAIN', 'PROPEPTIDE', 'PEPTIDE', 'TRANSIT']
     columns = base_columns + ['feature(%s)' % feat for feat in feature_types]
     columns_str = ','.join(columns)

--- a/protmapper/tests/test_uniprot_client.py
+++ b/protmapper/tests/test_uniprot_client.py
@@ -284,3 +284,10 @@ def test_get_feature_of():
 def test_entrez_uniprot():
     assert uniprot_client.get_entrez_id('Q66K41') == '201181'
     assert uniprot_client.get_id_from_entrez('201181') == 'Q66K41'
+
+
+def test_get_organism_id():
+    tid = uniprot_client.get_organism_id('P15056')
+    assert tid == '9606', tid
+    tid = uniprot_client.get_organism_id('P0DTC1')
+    assert tid == '2697049', tid

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def main():
     install_list = ['requests', 'rdflib', 'boto3']
 
     setup(name='protmapper',
-          version='0.0.18',
+          version='0.0.19',
           description='Map protein sites to human reference sequence.',
           long_description=long_description,
           long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR adds the taxonomy ID for each protein in the UniProt entries file and adds a function to the uniprot_client which returns the taxonomy ID for a given protein.