### PR TITLE
Return protein name if gene name is not available

### DIFF
--- a/protmapper/__init__.py
+++ b/protmapper/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.20'
+__version__ = '0.0.21'
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -133,10 +133,16 @@ def process_uniprot_line(line, base_columns, processed_columns,
     gene_name = gene_names_preferred[0]
     if not gene_name:
         gene_name = terms[8].split(' ')[0]
-    terms[1] = gene_name
 
     protein_names = parse_uniprot_synonyms(terms[9])
     protein_name = protein_names[0] if protein_names else None
+
+    if gene_name:
+        terms[1] = gene_name
+    elif protein_name:
+        terms[1] = protein_name
+    else:
+        terms[1] = None
 
     # Next we process the various features into a form that can be
     # loaded easily in the client

--- a/protmapper/tests/test_uniprot_client.py
+++ b/protmapper/tests/test_uniprot_client.py
@@ -307,3 +307,7 @@ def test_chain_is_main_protein():
     assert feature.is_main, feature
     feature = uniprot_client.get_feature_by_id('PRO_0000030311')
     assert not feature.is_main, feature
+
+
+def test_get_gene_name_only_protein_name():
+    assert uniprot_client.get_gene_name('P04377') == 'Pseudoazurin'

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -256,7 +256,10 @@ def get_id_from_mnemonic(uniprot_mnemonic):
 
 
 def get_gene_name(protein_id, web_fallback=True):
-    """Return the gene name for the given UniProt ID.
+    """Return the gene name or canonical protein name for the given UniProt ID.
+
+    If available, this function returns the primary gene name provided by
+    UniProt. If not available, the primary protein name is returned.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR adds another layer to getting names for proteins, for entries where a gene name is not provided (as is the case for a number of non-human proteins, e.g. https://www.uniprot.org/uniprot/B1A4Q8), the primary protein name is returned as a name.