### PR TITLE
Use PyStow to locate resource directory

### DIFF
--- a/protmapper/api.py
+++ b/protmapper/api.py
@@ -3,7 +3,7 @@ import csv
 import pickle
 import logging
 from requests.exceptions import HTTPError
-from protmapper.resources import resource_dir
+from protmapper.resources import resource_dir_path
 from protmapper import phosphosite_client, uniprot_client
 
 
@@ -185,7 +185,7 @@ class ProtMapper(object):
         self.site_map = site_map
         # Set default cache path
         if cache_path is None:
-            cache_path = os.path.join(resource_dir, 'sm_cache.pkl')
+            cache_path = os.path.join(resource_dir_path, 'sm_cache.pkl')
         self._cache_path = cache_path
         self.use_cache = use_cache
         self._cache = {}

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -25,7 +25,7 @@ logger.setLevel(logging.INFO)
 # Can be specified with PROTMAPPER_HOME environment variable, otherwise defaults
 # to $HOME/.data/protmapper/<__version__>. The location of $HOME can be overridden with
 # the PYSTOW_HOME environment variable
-resource_dir = pystow.get('protmapper', __version__).as_posix()
+resource_dir = pystow.join('protmapper', __version__).as_posix()
 
 
 def _download_from_s3(key, out_file):

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -25,7 +25,8 @@ logger.setLevel(logging.INFO)
 # Can be specified with PROTMAPPER_HOME environment variable, otherwise defaults
 # to $HOME/.data/protmapper/<__version__>. The location of $HOME can be overridden with
 # the PYSTOW_HOME environment variable
-resource_dir = pystow.join('protmapper', __version__).as_posix()
+resource_dir_path = pystow.join('protmapper', __version__)
+resource_dir = resource_dir_path.as_posix()
 
 
 def _download_from_s3(key, out_file):
@@ -387,7 +388,7 @@ class ResourceManager(object):
         str
             The path to the resource file.
         """
-        return os.path.join(resource_dir, self.resource_map[resource_id][0])
+        return os.path.join(resource_dir_path, self.resource_map[resource_id][0])
 
     def get_download_fun(self, resource_id):
         """Return the download function for the given resource.

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -4,6 +4,7 @@ import csv
 import zlib
 import json
 import boto3
+import pystow
 import logging
 import argparse
 import requests
@@ -22,14 +23,7 @@ logger.setLevel(logging.INFO)
 
 # If the protmapper resource directory does not exist, try to create it
 home_dir = os.path.expanduser('~')
-resource_dir = os.path.join(home_dir, '.protmapper', __version__)
-
-
-if not os.path.isdir(resource_dir):
-    try:
-        os.makedirs(resource_dir)
-    except Exception:
-        logger.warning(resource_dir + ' already exists')
+resource_dir = pystow.get('protmapper', __version__).as_posix()
 
 
 def _download_from_s3(key, out_file):

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -21,8 +21,10 @@ logger = logging.getLogger('protmapper.resources')
 logger.setLevel(logging.INFO)
 
 
-# If the protmapper resource directory does not exist, try to create it
-home_dir = os.path.expanduser('~')
+# If the protmapper resource directory does not exist, try to create it using PyStow
+# Can be specified with PROTMAPPER_HOME environment variable, otherwise defaults
+# to $HOME/.data/protmapper/<__version__>. The location of $HOME can be overridden with
+# the PYSTOW_HOME environment variable
 resource_dir = pystow.get('protmapper', __version__).as_posix()
 
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(path.join(here, 'protmapper', '__init__.py'), 'r') as fh:
 
 
 def main():
-    install_list = ['requests', 'rdflib', 'boto3', 'pystow']
+    install_list = ['requests', 'rdflib', 'boto3', 'pystow>=0.1.0']
 
     setup(name='protmapper',
           version=version,

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open(path.join(here, 'protmapper', '__init__.py'), 'r') as fh:
 
 
 def main():
-    install_list = ['requests', 'rdflib', 'boto3']
+    install_list = ['requests', 'rdflib', 'boto3', 'pystow']
 
     setup(name='protmapper',
           version=version,


### PR DESCRIPTION
Most INDRA-related resources create a folder in the home directory as a dot-file such as `$HOME/.protmapper`. I found that I had so many of these that I stared grouping them inside a `$HOME/.data` folder. It's also the case that every time you create one of these folders, you need to ensure its existence.

The [`pystow`](https://github.com/cthoyt/pystow) library takes care of these things. You use code like this:

```python
import pystow
from pathlib import Path

resource_dir_path: Path = pystow.join('protmapper')
resource_dir = resource_dir_path.as_posix()  # get a normal string back
```

First, it takes the name of the module, uppercases it, and postpends `_HOME` on to it (e.g., `PROTMAPPER_HOME`) and looks in the environment. If this variable is available, it uses that as the directory. It ensures it exists, then returns a `pathlib.Path` pointing to it.

If `PROTMAPPER_HOME` (or more generally, `<MODULENAME>_HOME` is not available in the environment, it picks the path as `$HOME/.data/<module name>`. Normally, `$HOME` is specified in your OS. However, if you want to pick another location to stick the data, you can override using `$HOME` by setting `$PYSTOW_HOME` in the environment.

If you want to go more directories deep inside the protmapper default directory, you can just keep using more positional arguments (the same semantics as `os.path.join()`). These directories automatically get created as well.

```python
import pystow
from pathlib import Path

# already set somewhere
__version__ = ...

resource_dir: Path = pystow.join('protmapper', __version__)
```
