### PR TITLE
Add Entrez mappings for non-human entries

### DIFF
--- a/protmapper/__init__.py
+++ b/protmapper/__init__.py
@@ -1,4 +1,5 @@
-__version__ = '0.0.21'
+__version__ = '0.0.22'
+import os
 import logging
 
 logging.basicConfig(format=('%(levelname)s: [%(asctime)s] %(name)s'
@@ -13,5 +14,6 @@ logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
 logger = logging.getLogger('protmapper')
 
-from protmapper.api import ProtMapper, MappedSite
-from protmapper.resources import resource_dir
+if not os.environ.get('INITIAL_RESOURCE_DOWNLOAD'):
+    from protmapper.api import ProtMapper, MappedSite
+    from protmapper.resources import resource_dir

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -141,6 +141,10 @@ def process_uniprot_line(line, base_columns, processed_columns,
     else:
         terms[1] = None
 
+    # We only add Entrez IDs for reviewed entries to avoid the problem
+    # caused by one-to-many mappings with lots of unreviewed proteins
+    terms[8] = '' if terms[6] != 'reviewed' else terms[8]
+
     # Next we process the various features into a form that can be
     # loaded easily in the client
     features = []

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -70,7 +70,7 @@ def download_uniprot_entries(out_file, cached=True):
         return
     base_columns = ['id', 'genes(PREFERRED)', 'entry%20name',
                     'database(RGD)', 'database(MGI)', 'length', 'reviewed',
-                    'organism-id']
+                    'organism-id', 'database(GeneID)']
     processed_columns = ['genes', 'protein%20names']
     feature_types = ['SIGNAL', 'CHAIN', 'PROPEPTIDE', 'PEPTIDE', 'TRANSIT']
     columns = base_columns + processed_columns + \
@@ -280,7 +280,7 @@ def download_uniprot_sec_ac(out_file, cached=True):
 
     logger.info('Downloading UniProt secondary accession mappings')
     url = 'ftp://ftp.uniprot.org/pub/databases/uniprot/knowledgebase/' + \
-        'docs/sec_ac.txt'
+        'complete/docs/sec_ac.txt'
     urlretrieve(url, out_file)
 
 

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -129,9 +129,9 @@ def process_uniprot_line(line, base_columns, processed_columns,
     gene_names_preferred = terms[1].split(';')
     gene_name = gene_names_preferred[0]
     if not gene_name:
-        gene_name = terms[8].split(' ')[0]
+        gene_name = terms[len(base_columns)].split(' ')[0]
 
-    protein_names = parse_uniprot_synonyms(terms[9])
+    protein_names = parse_uniprot_synonyms(terms[len(base_columns)+1])
     protein_name = protein_names[0] if protein_names else None
 
     if gene_name:

--- a/protmapper/tests/test_uniprot_client.py
+++ b/protmapper/tests/test_uniprot_client.py
@@ -282,8 +282,14 @@ def test_get_feature_of():
 
 
 def test_entrez_uniprot():
+    # This oen comes only from HGNC
     assert uniprot_client.get_entrez_id('Q66K41') == '201181'
     assert uniprot_client.get_id_from_entrez('201181') == 'Q66K41'
+    # This is unreviewed so we don't add it
+    assert uniprot_client.get_entrez_id('Q5VZ30') is None
+    # This comes only from UniProt
+    assert uniprot_client.get_entrez_id('Q05329') == '2572'
+    assert uniprot_client.get_id_from_entrez('2572') == 'Q05329'
 
 
 def test_get_organism_id():

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -980,11 +980,13 @@ class UniprotMapper(object):
          self._organisms_by_id, _uniprot_entrez,
          _entrez_uniprot) = maps
 
-        # Here we always overwrite the value to prioritize
+        # Here we don't overwrite the value to de-prioritize
         for k, v in _uniprot_entrez.items():
-            self._uniprot_entrez[k] = v
+            if k not in self._uniprot_entrez:
+                self._uniprot_entrez[k] = v
         for k, v in _entrez_uniprot.items():
-            self._entrez_uniprot[k] = v
+            if k not in self._entrez_uniprot:
+                self._entrez_uniprot[k] = v
 
         self._uniprot_sec = _build_uniprot_sec()
 
@@ -996,13 +998,11 @@ class UniprotMapper(object):
         _, _, self._uniprot_hgnc, _entrez_uniprot, \
             _uniprot_entrez = _build_hgnc_mappings()
 
-        # Here we don't overwrite the value to de-prioritize
+        # Here we always overwrite the value to prioritize
         for k, v in _uniprot_entrez.items():
-            if k not in self._uniprot_entrez:
-                self._uniprot_entrez[k] = v
+            self._uniprot_entrez[k] = v
         for k, v in _entrez_uniprot.items():
-            if k not in self._entrez_uniprot:
-                self._entrez_uniprot[k] = v
+            self._entrez_uniprot[k] = v
 
         self.initialized_hgnc = True
 

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -999,10 +999,12 @@ class UniprotMapper(object):
             _uniprot_entrez = _build_hgnc_mappings()
 
         # Here we always overwrite the value to prioritize
-        for k, v in _uniprot_entrez.items():
-            self._uniprot_entrez[k] = v
-        for k, v in _entrez_uniprot.items():
-            self._entrez_uniprot[k] = v
+        for upid, egid in _uniprot_entrez.items():
+            for uid in upid.split(', '):
+                self._uniprot_entrez[uid] = egid
+        for egid, upid in _entrez_uniprot.items():
+            if ',' not in upid:
+                self._entrez_uniprot[egid] = upid
 
         self.initialized_hgnc = True
 


### PR DESCRIPTION
This PR adds mappings provided by UniProt to/from Entrez for reviewed entries, both human and non-human. However, the previous mappings (only for human genes) sourced from HGNC are retained without change.