### PR TITLE
Improve protein name extraction and compress resource files

### DIFF
--- a/protmapper/__init__.py
+++ b/protmapper/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.0.22'
+__version__ = '0.0.23'
 import os
 import logging
 

--- a/protmapper/phosphosite_client.py
+++ b/protmapper/phosphosite_client.py
@@ -1,4 +1,5 @@
 import csv
+import gzip
 import logging
 from os.path import dirname, abspath, join
 from collections import namedtuple, defaultdict
@@ -77,7 +78,7 @@ def _get_phospho_site_dataset():
     global _data_by_site_grp
     phosphosite_data_file = resource_manager.get_create_resource_file('psp')
     if _data_by_up is None or _data_by_site_grp is None:
-        with open(phosphosite_data_file, 'r') as fh:
+        with gzip.open(phosphosite_data_file, 'rt', encoding='utf-8') as fh:
             # Get the csv reader generator
             reader = csv.reader(fh, delimiter='\t')
             # Skip 4 rows

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -122,8 +122,6 @@ def download_uniprot_entries(out_file, cached=True):
 
 def process_uniprot_line(line, base_columns, processed_columns,
                          feature_types):
-    if 'P84122' in line:
-        breakpoint()
     terms = line.split('\t')
 
     # At this point, we need to clean up the gene names.
@@ -190,8 +188,10 @@ def parse_uniprot_synonyms(synonyms_str):
             return [synonyms_str] + syns
 
         syn = find_block_from_right(synonyms_str)
-        syns = [syn] + syns
         synonyms_str = synonyms_str[:-len(syn)-3]
+        # EC codes are not valid synonyms
+        if not re.match(r'EC [\d\.-]+', syn):
+            syns = [syn] + syns
 
 
 Feature = namedtuple('Feature', ['type', 'begin', 'end', 'name', 'id',

--- a/protmapper/resources.py
+++ b/protmapper/resources.py
@@ -122,6 +122,8 @@ def download_uniprot_entries(out_file, cached=True):
 
 def process_uniprot_line(line, base_columns, processed_columns,
                          feature_types):
+    if 'P84122' in line:
+        breakpoint()
     terms = line.split('\t')
 
     # At this point, we need to clean up the gene names.
@@ -161,7 +163,7 @@ def process_uniprot_line(line, base_columns, processed_columns,
 def parse_uniprot_synonyms(synonyms_str):
     synonyms_str = re.sub(r'\[Includes: ([^]])+\]',
                           '', synonyms_str).strip()
-    synonyms_str = re.sub(r'\[Cleaved into: ([^]])+\]',
+    synonyms_str = re.sub(r'\[Cleaved into: ([^]])+\]( \(Fragments\))?',
                           '', synonyms_str).strip()
 
     def find_block_from_right(s):

--- a/protmapper/tests/test_uniprot_client.py
+++ b/protmapper/tests/test_uniprot_client.py
@@ -1,5 +1,5 @@
 from protmapper import uniprot_client
-from protmapper.resources import _process_feature
+from protmapper.resources import _process_feature, parse_uniprot_synonyms
 from nose.plugins.attrib import attr
 
 
@@ -317,3 +317,14 @@ def test_chain_is_main_protein():
 
 def test_get_gene_name_only_protein_name():
     assert uniprot_client.get_gene_name('P04377') == 'Pseudoazurin'
+
+
+def test_protein_name_no_ec_code():
+    assert uniprot_client.get_gene_name('P84122') == 'Thrombin'
+
+
+def test_parse_synonym():
+    syn_str = ('Thrombin (EC 3.4.21.5) [Cleaved into: Thrombin light chain; '
+               'Thrombin heavy chain] (Fragments)')
+    syns = parse_uniprot_synonyms(syn_str)
+    assert syns == ['Thrombin'], syns

--- a/protmapper/uniprot_client.py
+++ b/protmapper/uniprot_client.py
@@ -1,5 +1,6 @@
 import re
 import csv
+import gzip
 import json
 import logging
 import requests
@@ -1162,7 +1163,7 @@ def _build_uniprot_entries():
     uniprot_entrez_reverse = {}
     files = [up_entries_file]
     for file in files:
-        with open(file, 'r') as fh:
+        with gzip.open(file, 'rt', encoding='utf-8') as fh:
             csv_rows = csv.reader(fh, delimiter='\t')
             # Skip the header row
             next(csv_rows)
@@ -1212,7 +1213,7 @@ def _build_uniprot_entries():
 
 def _build_human_mouse_rat():
     hgnc_file = resource_manager.get_create_resource_file('hgnc')
-    with open(hgnc_file, 'r') as fh:
+    with gzip.open(hgnc_file, 'rt', encoding='utf-8') as fh:
         csv_rows = csv.reader(fh, delimiter='\t')
         # Skip the header row
         next(csv_rows)
@@ -1240,7 +1241,7 @@ def _build_human_mouse_rat():
 
 def _build_hgnc_mappings():
     hgnc_file = resource_manager.get_create_resource_file('hgnc')
-    with open(hgnc_file, 'r') as fh:
+    with gzip.open(hgnc_file, 'rt', encoding='utf-8') as fh:
         csv_rows = csv.reader(fh, delimiter='\t')
         # Skip the header row
         next(csv_rows)
@@ -1309,7 +1310,7 @@ def _build_refseq_uniprot():
     refseq_uniprot_file = resource_manager.get_create_resource_file(
                                                 'refseq_uniprot')
     refseq_up = {}
-    with open(refseq_uniprot_file, 'rt') as f:
+    with gzip.open(refseq_uniprot_file, 'rt', encoding='utf-8') as f:
         csvreader = csv.reader(f)
         for refseq_id, up_id in csvreader:
             if refseq_id not in refseq_up:
@@ -1320,7 +1321,7 @@ def _build_refseq_uniprot():
 
 def load_fasta_sequences(seq_file, id_delimiter='|', id_index=1):
     sequences = {}
-    with open(seq_file, 'rt') as f:
+    with gzip.open(seq_file, 'rt', encoding='utf-8') as f:
         lines = f.readlines()
         cur_id = None
         seq_lines = []


### PR DESCRIPTION
This PR fixes an issue with processing protein names out of the UniProt TSV download in complicated corner cases like this one:
```
Thrombin (EC 3.4.21.5) [Cleaved into: Thrombin light chain; Thrombin heavy chain] (Fragments)
```
The PR also changes all resource files to be stored as compressed files which reduces their size by about 72% overall.